### PR TITLE
Updated code examples to working code for 3.4

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -29,6 +29,12 @@ Basic example
             $this->setTable('users');
             $this->setDisplayField('name');
             $this->setPrimaryKey('id');
+
+            // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous:
+            // $this->table('users');
+            // $this->displayField('name');
+            // $this->primaryKey('id');
+
             $this->addBehavior('Josegonzalez/Upload.Upload', [
                 // You can configure as many upload fields as possible,
                 // where the pattern is `field` => `config`
@@ -45,9 +51,14 @@ Basic example
 .. code:: php
 
     <?php echo $this->Form->create($user, ['type' => 'file']); ?>
-    <?php echo $this->Form->input('username'); ?>
-    <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
+        <?php echo $this->Form->input('username'); ?>
+        <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
     <?php echo $this->Form->end(); ?>
+    <?php // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous ?>
+        <?php // echo $this->Form->create('User', ['type' => 'file']); ?>
+        <?php // echo $this->Form->input('User.username'); ?>
+        <?php // echo $this->Form->input('User.photo', ['type' => 'file']); ?>
+    <?php // echo $this->Form->end(); ?>
 
 Using the above setup, uploaded files cannot be deleted. To do so, a
 field must be added to store the directory of the file as follows:
@@ -74,9 +85,15 @@ field must be added to store the directory of the file as follows:
     {
         public function initialize(array $config)
         {
-            $this->table('users');
-            $this->displayField('name');
-            $this->primaryKey('id');
+            $this->setTable('users');
+            $this->setDisplayField('name');
+            $this->setPrimaryKey('id');
+
+            // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous:
+            // $this->table('users');
+            // $this->displayField('name');
+            // $this->primaryKey('id');
+
             $this->addBehavior('Josegonzalez/Upload.Upload', [
                 'photo' => [
                     'fields' => [
@@ -99,6 +116,14 @@ field must be added to store the directory of the file as follows:
         <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
         <?php echo $this->Form->input('photo_dir', ['type' => 'hidden']); ?>
     <?php echo $this->Form->end(); ?>
+    <?php // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous ?>
+    <?php // echo $this->Form->create('User', ['type' => 'file']); ?>
+        <?php // echo $this->Form->input('User.username'); ?>
+        <?php // echo $this->Form->input('User.photo', ['type' => 'file']); ?>
+        <?php // echo $this->Form->input('User.photo_dir', ['type' => 'hidden']); ?>
+    <?php // echo $this->Form->end(); ?>
+
+
 
 Displaying links to files in your view
 --------------------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -54,11 +54,6 @@ Basic example
         <?php echo $this->Form->input('username'); ?>
         <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
     <?php echo $this->Form->end(); ?>
-    <?php // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous ?>
-        <?php // echo $this->Form->create('User', ['type' => 'file']); ?>
-        <?php // echo $this->Form->input('User.username'); ?>
-        <?php // echo $this->Form->input('User.photo', ['type' => 'file']); ?>
-    <?php // echo $this->Form->end(); ?>
 
 Using the above setup, uploaded files cannot be deleted. To do so, a
 field must be added to store the directory of the file as follows:
@@ -116,14 +111,6 @@ field must be added to store the directory of the file as follows:
         <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
         <?php echo $this->Form->input('photo_dir', ['type' => 'hidden']); ?>
     <?php echo $this->Form->end(); ?>
-    <?php // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous ?>
-    <?php // echo $this->Form->create('User', ['type' => 'file']); ?>
-        <?php // echo $this->Form->input('User.username'); ?>
-        <?php // echo $this->Form->input('User.photo', ['type' => 'file']); ?>
-        <?php // echo $this->Form->input('User.photo_dir', ['type' => 'hidden']); ?>
-    <?php // echo $this->Form->end(); ?>
-
-
 
 Displaying links to files in your view
 --------------------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -26,9 +26,9 @@ Basic example
     {
         public function initialize(array $config)
         {
-            $this->table('users');
-            $this->displayField('name');
-            $this->primaryKey('id');
+            $this->setTable('users');
+            $this->setDisplayField('name');
+            $this->setPrimaryKey('id');
             $this->addBehavior('Josegonzalez/Upload.Upload', [
                 // You can configure as many upload fields as possible,
                 // where the pattern is `field` => `config`
@@ -44,9 +44,9 @@ Basic example
 
 .. code:: php
 
-    <?php echo $this->Form->create('User', ['type' => 'file']); ?>
-    <?php echo $this->Form->input('User.username'); ?>
-    <?php echo $this->Form->input('User.photo', ['type' => 'file']); ?>
+    <?php echo $this->Form->create($user, ['type' => 'file']); ?>
+    <?php echo $this->Form->input('username'); ?>
+    <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
     <?php echo $this->Form->end(); ?>
 
 Using the above setup, uploaded files cannot be deleted. To do so, a
@@ -94,10 +94,10 @@ field must be added to store the directory of the file as follows:
 
 .. code:: php
 
-    <?php echo $this->Form->create('User', ['type' => 'file']); ?>
-        <?php echo $this->Form->input('User.username'); ?>
-        <?php echo $this->Form->input('User.photo', ['type' => 'file']); ?>
-        <?php echo $this->Form->input('User.photo_dir', ['type' => 'hidden']); ?>
+    <?php echo $this->Form->create($user, ['type' => 'file']); ?>
+        <?php echo $this->Form->input('username'); ?>
+        <?php echo $this->Form->input('photo', ['type' => 'file']); ?>
+        <?php echo $this->Form->input('photo_dir', ['type' => 'hidden']); ?>
     <?php echo $this->Form->end(); ?>
 
 Displaying links to files in your view

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -27,12 +27,12 @@ Basic example
         public function initialize(array $config)
         {
             $this->setTable('users');
-            $this->setDisplayField('name');
+            $this->setDisplayField('username');
             $this->setPrimaryKey('id');
 
             // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous:
             // $this->table('users');
-            // $this->displayField('name');
+            // $this->displayField('username');
             // $this->primaryKey('id');
 
             $this->addBehavior('Josegonzalez/Upload.Upload', [
@@ -81,12 +81,12 @@ field must be added to store the directory of the file as follows:
         public function initialize(array $config)
         {
             $this->setTable('users');
-            $this->setDisplayField('name');
+            $this->setDisplayField('username');
             $this->setPrimaryKey('id');
 
             // for CakePHP 3.0.x-3.3.x, use the following lines instead of the previous:
             // $this->table('users');
-            // $this->displayField('name');
+            // $this->displayField('username');
             // $this->primaryKey('id');
 
             $this->addBehavior('Josegonzalez/Upload.Upload', [


### PR DESCRIPTION
I tried using the existing documentation to set up CakePHP-upload for the first time and ran into a few issues. This pull request reflects the changes I had to make to get it to work.

* As of CakePHP 3.4, the initialize() function uses setTable(), setDisplayField(), and setPrimaryKey() instead of the method names not including 'set';
* It looks like the Form helper used Model names in some earlier version of CakePHP, but those now get left out. I changed to using `$user` instead of `User` in lines 47 & 97; I removed the 'User.' from the field names in the input.