### PR TITLE
is_resource() before fclose()

### DIFF
--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -124,7 +124,7 @@ class DefaultWriter implements WriterInterface
             $success = $filesystem->rename($tempPath, $path);
         }
         $this->deletePath($filesystem, $tempPath);
-        fclose($stream);
+        is_resource($stream) && fclose($stream);
 
         return $success;
     }


### PR DESCRIPTION
Sometimes, DefaultWriter.php raise PHP warning when manipulating multiple/large files in a short time.

```
Warning Error: fclose(): supplied resource is not a valid stream resource in [/path/to/vendor/josegonzalez/cakephp-upload/src/File/Writer/DefaultWrit
er.php, line 127]
```

So use `is_resource()` before `fclose()`. 
( see https://github.com/thephpleague/flysystem/issues/763 )