### PR TITLE
Improve nameCallback by adding $table, $entry and $field

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,7 +67,10 @@ passed in under each field in your behavior configuration.
    -  Default: ``NULL``
    -  Available arguments:
 
+      -  ``Table $table``: The table of the current entity
+      -  ``Entity $entity``: The entity you want to add/edit
       -  ``array $data``: The upload data
+      -  ``string $field``: The field for which data will be added/edited
       -  ``array $settings``: UploadBehavior settings for the current field
 
    -  Return: (string) the new name for the file

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -224,7 +224,7 @@ This example uses the Imagine library. It can be installed through composer:
                         'size' => 'photo_size',
                         'type' => 'photo_type'
                     ],
-                    'nameCallback' => function ($data, $settings) {
+                    'nameCallback' => function ($table, $entity, $data, $field, $settings) {
                         return strtolower($data['name']);
                     },
                     'transformer' =>  function ($table, $entity, $data, $field, $settings) {

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -16,6 +16,11 @@ trait DefaultTrait
     {
         $processor = Hash::get($this->settings, 'nameCallback', null);
         if (is_callable($processor)) {
+            $numberOfParameters = (new \ReflectionFunction($processor))->getNumberOfParameters();
+            if ($numberOfParameters == 2) {
+                return $processor($this->data, $this->settings);
+            }
+
             return $processor($this->table, $this->entity, $this->data, $this->field, $this->settings);
         }
 

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -16,7 +16,7 @@ trait DefaultTrait
     {
         $processor = Hash::get($this->settings, 'nameCallback', null);
         if (is_callable($processor)) {
-            return $processor($this->data, $this->settings);
+            return $processor($this->table, $this->entity, $this->data, $this->field, $this->settings);
         }
 
         return $this->data['name'];

--- a/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
@@ -23,8 +23,11 @@ class DefaultTraitTest extends TestCase
         $this->assertEquals('filename', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
+        $mock->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
+        $mock->table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $mock->field = 'field';
         $mock->settings = [
-            'nameCallback' => function ($data, $settings) {
+            'nameCallback' => function ($table, $entity, $data, $field, $settings) {
                 return $data;
             },
         ];

--- a/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
@@ -23,6 +23,15 @@ class DefaultTraitTest extends TestCase
         $this->assertEquals('filename', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
+        $mock->settings = [
+            'nameCallback' => function ($data, $settings) {
+                return $data;
+            },
+        ];
+        $mock->data = ['name' => 'filename'];
+        $this->assertEquals(['name' => 'filename'], $mock->filename());
+
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $mock->table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $mock->field = 'field';


### PR DESCRIPTION
### This adds `$table`, `$entry` and `$field` to the signature of the `nameCallback` function.
```php
'nameCallback' => function ($table, $entity, $data, $field, $settings) { ... }
````
That gives the ability to change the `filename` more dynamically.

### For example
It is now possible to update the name of a file only if it is a new entity:
```php
'nameCallback' => function ($table, $entity, $data, $field, $settings) {
    // Rename destination filename
    $ext = pathinfo($data['name'], PATHINFO_EXTENSION);
    if (!empty($ext)) {
        $ext = '.' . $ext;
    }
    if ($entity->isNew()) {
        $data['name'] = uniqid() . $ext;
    } else {
        $filename = pathinfo($entity->getOriginal($field), PATHINFO_FILENAME);
        $data['name'] = $filename . $ext;
    }
    return $data['name'];
},
```