### PR TITLE
Introduction of protected field names

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,5 +1,17 @@
+Configuration
+=============
+
+Protected field names
+---------------------
+
+As this plugin is a Behavior, there are some field names you can not use
+because they are used by the internal CakePHP system. Please do not these
+field names:
+
+- priority
+
 Behavior configuration options
-==============================
+------------------------------
 
 This is a list of all the available configuration options which can be
 passed in under each field in your behavior configuration.

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -16,6 +16,9 @@ use UnexpectedValueException;
 
 class UploadBehavior extends Behavior
 {
+    private $protectedFieldNames = [
+        'priority',
+    ];
 
     /**
      * Initialize hook
@@ -80,6 +83,10 @@ class UploadBehavior extends Behavior
     public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
     {
         foreach ($this->config() as $field => $settings) {
+            if (in_array($field, $this->protectedFieldNames)) {
+                continue;
+            }
+
             if (Hash::get((array)$entity->get($field), 'error') !== UPLOAD_ERR_OK) {
                 if (Hash::get($settings, 'restoreValueOnFailure', true)) {
                     $entity->set($field, $entity->getOriginal($field));

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -347,7 +347,23 @@ class UploadBehaviorTest extends TestCase
         $behavior->config($settings);
         $this->entity->expects($this->never())->method('getOriginal');
         $this->entity->expects($this->never())->method('set');
+
         $behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject);
+    }
+
+    public function testBeforeSaveWithProtectedFieldName()
+    {
+        $settings = $this->settings;
+        $settings['priority'] = 11;
+
+        $methods = array_diff($this->behaviorMethods, ['beforeSave', 'config', 'setConfig', 'getConfig']);
+        $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->table, $this->settings])
+            ->getMock();
+        $behavior->config($settings);
+
+        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject));
     }
 
     public function testAfterDeleteOk()


### PR DESCRIPTION
This protects the system from taking a behavior setting as a file upload field. I came across this issue when using the priority flag as documented on https://api.cakephp.org/3.3/class-Cake.ORM.Behavior.html