### PR TITLE
Protected fields afterDelete fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
   - sh -c "if [ '$DB' = 'mysql' ]; then if [ '$DOCKER' = '1' ]; then apt-get -qq install -qq -y mysql-server && service mysql start; fi; mysql -e 'CREATE DATABASE cakephp_test;'; fi"
 
@@ -44,7 +44,7 @@ before_script:
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require 'cakephp/cakephp-codesniffer:dev-master'; fi"
 
-  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls:dev-master; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev satooshi/php-coveralls; fi"
   - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
   - command -v phpenv > /dev/null && phpenv rehash || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 
 script:
   - sh -c "if [ '$COVERALLS' = '1' ]; then vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
-  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -v; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/php-coveralls -v; fi"
   - sh -c "if [ '$DEFAULT' = '1' ]; then vendor/bin/phpunit --stderr; fi"
   - sh -c "if [ '$PHPCS' = '1' ]; then vendor/bin/phpcs -n -p --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "<6.0",
         "league/flysystem-vfs": "*",
         "cakephp/cakephp-codesniffer": "dev-master",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -129,7 +129,7 @@ class UploadBehavior extends Behavior
         $result = true;
 
         foreach ($this->config() as $field => $settings) {
-            if (Hash::get($settings, 'keepFilesOnDelete', true)) {
+            if (in_array($field, $this->protectedFieldNames) || Hash::get($settings, 'keepFilesOnDelete', true)) {
                 continue;
             }
 

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -586,6 +586,27 @@ class UploadBehaviorTest extends TestCase
         $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject);
     }
 
+    public function testAfterDeleteWithProtectedFieldName()
+    {
+        $settings = $this->settings;
+        $settings['priority'] = 11;
+
+        $methods = array_diff($this->behaviorMethods, ['afterDelete', 'config', 'setConfig', 'getConfig']);
+        $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
+            ->setMethods($methods)
+            ->setConstructorArgs([$this->table, $settings])
+            ->getMock();
+
+        $behavior->expects($this->any())
+            ->method('getWriter')
+            ->will($this->returnValue($this->writer));
+        $this->writer->expects($this->any())
+            ->method('delete')
+            ->will($this->returnValue([true]));
+
+        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+    }
+
     public function testGetWriter()
     {
         $processor = $this->behavior->getWriter($this->entity, [], 'field', []);


### PR DESCRIPTION
While introducing protected fields there was no test for the afterDelete method. When using a protected field, afterDelete should skip this value.