### PR TITLE
Add flattenImages option

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -52,6 +52,7 @@ class UploadBehavior extends ModelBehavior {
 		'mode' => 0777,
 		'handleUploadedFileCallback' => null,
 		'nameCallback' => null,
+		'flattenImages' => false,
 	);
 
 	protected $_imageMimetypes = array(
@@ -1186,6 +1187,10 @@ class UploadBehavior extends ModelBehavior {
 		$this->_exifRotateImagick($image);
 		$height = $image->getImageHeight();
 		$width = $image->getImageWidth();
+
+		if ($this->settings[$model->alias][$field]['flattenImages']) {
+			$image = $image->flattenImages();
+		}
 
 		if (preg_match('/^\\[[\\d]+x[\\d]+\\]$/', $geometry)) {
 			// resize with banding

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -242,3 +242,8 @@ passed in under each field in your behavior configuration.
    -  Return: String - returns the new name for the file
 
 
+-  ``flattenImages``: Call the Imagick ``flattenImages()`` method on
+   resize. Setting this to ``true`` when converting pdf files to jpg
+   thumbnails can help with black background issues.
+
+   -  Default: (boolean) ``false``


### PR DESCRIPTION
A recent [ImageMagick update](https://launchpad.net/ubuntu/+source/imagemagick/8:6.7.7.10-6ubuntu3.13) in an older Ubuntu distribution (14.04.5 LTS) broke existing pdf to jpg thumbnail conversion for us. After some digging, the included change here prevents generated jpg files from having a black background. 

Note that `$image = $image->flattenImages()` isn't a typo, simply calling `flattenImages()` has no effect.