### PR TITLE
Updating tests to pass with CakePHP 3.7.3

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
+ * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
+ * @link          https://cakephp.org CakePHP(tm) Project
+ * @since         DebugKit 3.15.0
+ * @license       https://www.opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Josegonzalez\Upload;
+
+use Cake\Core\BasePlugin;
+
+/**
+ * Plugin class for CakePHP 3.6.0 plugin collection.
+ */
+class Plugin extends BasePlugin
+{
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,16 +1,4 @@
 <?php
-/**
- * CakePHP(tm) : Rapid Development Framework (https://cakephp.org)
- * Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- *
- * Licensed under The MIT License
- * Redistributions of files must retain the above copyright notice.
- *
- * @copyright     Copyright (c) Cake Software Foundation, Inc. (https://cakefoundation.org)
- * @link          https://cakephp.org CakePHP(tm) Project
- * @since         DebugKit 3.15.0
- * @license       https://www.opensource.org/licenses/mit-license.php MIT License
- */
 
 namespace Josegonzalez\Upload;
 

--- a/tests/Fixture/FilesFixture.php
+++ b/tests/Fixture/FilesFixture.php
@@ -14,7 +14,7 @@ class FilesFixture extends TestFixture
      */
     public $fields = [
         'id' => ['type' => 'integer'],
-        'filename' => ['type' => 'integer'],
+        'filename' => ['type' => 'string'],
         'created' => ['type' => 'datetime', 'null' => true],
         '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
     ];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -64,7 +64,7 @@ Cake\Core\Configure::write('Session', [
     'defaults' => 'php'
 ]);
 
-Cake\Core\Plugin::load('Josegonzalez/Upload', ['path' => ROOT . DS, 'autoload' => true]);
+\Cake\Core\Plugin::getCollection()->add(new \Josegonzalez\Upload\Plugin);
 
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {


### PR DESCRIPTION
When running tests, these errors and warnings occurred:

1. `Plugin::load() is deprecated. Use Application::addPlugin() instead. This method will be removed in 4.0.0.`

2. `Uncaught InvalidArgumentException: Cannot convert value of type string to integer in cakephp-upload/vendor/cakephp/cakephp/src/Database/Type/IntegerType.php:64`

Fixed by:
1. Changed how the plugin is added in tests.
2. Changed test fixture filename field from integer to string.