### PR TITLE
Add image validation method exactDimensions

### DIFF
--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -249,3 +249,21 @@ pixels)
         ]);
 
     ?>
+
+
+**isExactDimensions**
+
+Check that the file is exactly the width and height requirement (checked in
+pixels)
+
+.. code:: php
+
+    <?php
+
+        $validator->add('file', 'fileExactDimensions', [
+            'rule' => ['isExactDimensions', 200, 150],
+            'message' => 'This image should not be exactly 200px wide and 150px high',
+            'provider' => 'upload'
+        ]);
+
+    ?>

--- a/src/Validation/Traits/ImageValidationTrait.php
+++ b/src/Validation/Traits/ImageValidationTrait.php
@@ -75,4 +75,23 @@ trait ImageValidationTrait
 
         return $height > 0 && $imgHeight <= $height;
     }
+
+    /**
+     * Check that the file is the exact width and height requirement
+     *
+     * @param mixed $check Value to check
+     * @param int $width Width of Image
+     * @param int $height Height of Image
+     * @return bool Success
+     */
+    public static function isExactDimensions($check, $width, $height)
+    {
+        // Non-file uploads also mean the height is too big
+        if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+            return false;
+        }
+        list($imgWidth, $imgHeight) = getimagesize($check['tmp_name']);
+
+        return $width > 0 && $imgWidth === $width && $height > 0 && $imgHeight === $height;
+    }
 }

--- a/tests/TestCase/Validation/ImageValidationTest.php
+++ b/tests/TestCase/Validation/ImageValidationTest.php
@@ -88,4 +88,17 @@ class ImageValidationTest extends TestCase
         unset($this->data['tmp_name']);
         $this->assertFalse(ImageValidation::isBelowMaxHeight($this->data, 10));
     }
+
+    public function testIsExactDimensions()
+    {
+        $this->assertTrue(ImageValidation::isExactDimensions($this->data, 20, 20));
+        $this->assertFalse(ImageValidation::isExactDimensions($this->data, 30, 30));
+
+        // Test if no tmp_name is set or specified
+        $this->data['tmp_name'] = '';
+        $this->assertFalse(ImageValidation::isExactDimensions($this->data, 20, 20));
+
+        unset($this->data['tmp_name']);
+        $this->assertFalse(ImageValidation::isExactDimensions($this->data, 20, 20));
+    }
 }


### PR DESCRIPTION
References issue #518 - Add image validation method checking that exact dimensions match.

##### Image Validation method `exactDimensions`

Currently you can check whether and image is below or above width and height, but no way to check if an image matches the exact dimensions. Granted, you can combine all of the existing validation to get there, but that means too much code.