### PR TITLE
Cake 4.x UploadedFile Fixes

### DIFF
--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -7,6 +7,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Josegonzalez\Upload\File\Path\Basepath\DefaultTrait as BasepathTrait;
 use Josegonzalez\Upload\File\Path\Filename\DefaultTrait as FilenameTrait;
+use Zend\Diactoros\UploadedFile;
 
 class DefaultProcessor implements ProcessorInterface
 {
@@ -28,9 +29,9 @@ class DefaultProcessor implements ProcessorInterface
     protected $entity;
 
     /**
-     * Array of uploaded data for this field or filename stored in db
+     * Instance of \Zend\Diactoros\UploadedFile conaining the meta info from the file.
      *
-     * @var array|string
+     * @var \Zend\Diactoros\UploadedFile
      */
     protected $data;
 
@@ -57,7 +58,7 @@ class DefaultProcessor implements ProcessorInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -7,7 +7,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Josegonzalez\Upload\File\Path\Basepath\DefaultTrait as BasepathTrait;
 use Josegonzalez\Upload\File\Path\Filename\DefaultTrait as FilenameTrait;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 class DefaultProcessor implements ProcessorInterface
 {
@@ -29,9 +29,9 @@ class DefaultProcessor implements ProcessorInterface
     protected $entity;
 
     /**
-     * Instance of \Zend\Diactoros\UploadedFile conaining the meta info from the file.
+     * Instance of \Psr\Http\Message\UploadedFileInterface conaining the meta info from the file.
      *
-     * @var \Zend\Diactoros\UploadedFile
+     * @var \Psr\Http\Message\UploadedFileInterface
      */
     protected $data;
 
@@ -58,7 +58,7 @@ class DefaultProcessor implements ProcessorInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -26,6 +26,6 @@ trait DefaultTrait
             return $processor($this->table, $this->entity, $this->data, $this->field, $this->settings);
         }
 
-        return $this->data['name'];
+        return $this->data->getClientFilename();
     }
 }

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\File\Path;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
+use Zend\Diactoros\UploadedFile;
 
 interface ProcessorInterface
 {
@@ -13,11 +14,11 @@ interface ProcessorInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param array|string     $data the data being submitted for a save or filename stored in db
+     * @param \Zend\Diactoros\UploadedFile     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
 
     /**
      * Returns the basepath for the current field/data combination

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -5,7 +5,7 @@ namespace Josegonzalez\Upload\File\Path;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 interface ProcessorInterface
 {
@@ -14,11 +14,11 @@ interface ProcessorInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param \Zend\Diactoros\UploadedFile     $data the data being submitted for a save or filename stored in db
+     * @param \Psr\Http\Message\UploadedFileInterface     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings);
 
     /**
      * Returns the basepath for the current field/data combination

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
+use Zend\Diactoros\UploadedFile;
 
 class DefaultTransformer implements TransformerInterface
 {
@@ -48,11 +49,11 @@ class DefaultTransformer implements TransformerInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;
@@ -75,6 +76,6 @@ class DefaultTransformer implements TransformerInterface
      */
     public function transform(): array
     {
-        return [$this->data['tmp_name'] => $this->data['name']];
+        return [$this->data->getStream()->getMetadata('uri') => $this->data->getClientFileName()];
     }
 }

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -5,7 +5,7 @@ namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 class DefaultTransformer implements TransformerInterface
 {
@@ -49,11 +49,11 @@ class DefaultTransformer implements TransformerInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -5,7 +5,7 @@ namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 interface TransformerInterface
 {
@@ -14,11 +14,11 @@ interface TransformerInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings);
 
     /**
      * Creates a set of files from the initial data and returns them as key/value

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
+use Zend\Diactoros\UploadedFile;
 
 interface TransformerInterface
 {
@@ -13,11 +14,11 @@ interface TransformerInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
 
     /**
      * Creates a set of files from the initial data and returns them as key/value

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -12,6 +12,7 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
 use UnexpectedValueException;
+use Zend\Diactoros\UploadedFile;
 
 class DefaultWriter implements WriterInterface
 {
@@ -55,11 +56,11 @@ class DefaultWriter implements WriterInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -12,7 +12,7 @@ use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
 use UnexpectedValueException;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 class DefaultWriter implements WriterInterface
 {
@@ -56,11 +56,11 @@ class DefaultWriter implements WriterInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\File\Writer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
+use Zend\Diactoros\UploadedFile;
 
 interface WriterInterface
 {
@@ -13,11 +14,11 @@ interface WriterInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
 
     /**
      * Writes a set of files to an output

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -5,7 +5,7 @@ namespace Josegonzalez\Upload\File\Writer;
 
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 interface WriterInterface
 {
@@ -14,11 +14,11 @@ interface WriterInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFile $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings);
 
     /**
      * Writes a set of files to an output

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -16,7 +16,7 @@ use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 use Josegonzalez\Upload\File\Writer\DefaultWriter;
 use Josegonzalez\Upload\File\Writer\WriterInterface;
 use UnexpectedValueException;
-use Zend\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 
 class UploadBehavior extends Behavior
 {
@@ -171,12 +171,12 @@ class UploadBehavior extends Behavior
      * for a given file upload
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Path\ProcessorInterface
      */
-    public function getPathProcessor(EntityInterface $entity, UploadedFile $data, string $field, array $settings): ProcessorInterface
+    public function getPathProcessor(EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings): ProcessorInterface
     {
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
 
@@ -187,12 +187,12 @@ class UploadBehavior extends Behavior
      * Retrieves an instance of a file writer which knows how to write files to disk
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Writer\WriterInterface
      */
-    public function getWriter(EntityInterface $entity, UploadedFile $data, string $field, array $settings): WriterInterface
+    public function getWriter(EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings): WriterInterface
     {
         $writerClass = Hash::get($settings, 'writer', DefaultWriter::class);
 
@@ -215,7 +215,7 @@ class UploadBehavior extends Behavior
      * create the source files.
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity
-     * @param \Zend\Diactoros\UploadedFile $data the data being submitted for a save
+     * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @param string $basepath a basepath where the files are written to
@@ -223,7 +223,7 @@ class UploadBehavior extends Behavior
      */
     public function constructFiles(
         EntityInterface $entity,
-        UploadedFile $data,
+        UploadedFileInterface $data,
         string $field,
         array $settings,
         string $basepath


### PR DESCRIPTION
Cake 4 uses the `\Zend\Diactoros\UploadedFile` class for uploaded files which broke the plugin.  Might be better to use the `UploadedFileInterface` here though.

Will look at tests soon just wanted to make the pull request because I keep on forgetting about it and did this quite some time ago.