### PR TITLE
Allow entity to update with non-dirty upload field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: php
 
 php:
-  - 5.6
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
+
+services:
+  - mysql
+  - postgresql
 
 env:
   matrix:
@@ -19,13 +22,13 @@ matrix:
   fast_finish: true
 
   include:
-    - php: 7.3
+    - php: 7.2
       env: PHPCS=1 DEFAULT=0
 
-    - php: 7.3
+    - php: 7.2
       env: STATIC_ANALYSIS=1 DEFAULT=0
 
-    - php: 5.6
+    - php: 7.2
       env: PREFER_LOWEST=1
 
 before_script:
@@ -37,7 +40,7 @@ before_script:
   - if [[ $DB = 'mysql' ]]; then mysql -e 'CREATE DATABASE cakephp_test;'; fi
   - if [[ $DB = 'pgsql' ]]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi
 
-  - if [[ $STATIC_ANALYSIS = 1 ]]; then composer require --dev phpstan/phpstan-shim:^0.11; fi
+  - if [[ $STATIC_ANALYSIS = 1 ]]; then composer require --dev phpstan/phpstan:^0.12; fi
 
 script:
   - |
@@ -54,7 +57,7 @@ script:
 
 after_success:
   - |
-      if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.3 ]]; then
+      if [[ $DEFAULT = 1 && $TRAVIS_PHP_VERSION = 7.2 ]]; then
         wget https://github.com/php-coveralls/php-coveralls/releases/download/v2.1.0/php-coveralls.phar
         chmod +x php-coveralls.phar
         ./php-coveralls.phar

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,13 @@
         }
     ],
     "require": {
-        "cakephp/orm": "^3.5",
+        "cakephp/cakephp": "4.x-dev",
         "league/flysystem": "*"
     },
     "require-dev": {
-        "cakephp/cakephp": "^3.5",
-        "cakephp/chronos": "^1.1",
-        "phpunit/phpunit": "^5.7.14|^6.0",
+        "phpunit/phpunit": "^8.0",
         "league/flysystem-vfs": "*",
-        "cakephp/cakephp-codesniffer": "dev-master"
+        "cakephp/cakephp-codesniffer": "dev-next"
     },
     "autoload": {
         "psr-4": {
@@ -32,5 +30,7 @@
         "psr-4": {
             "Josegonzalez\\Upload\\Test\\": "tests"
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-        "cakephp/cakephp": "4.x-dev",
+        "cakephp/cakephp": "^4.0",
         "league/flysystem": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "~8.5.0",
         "league/flysystem-vfs": "*",
-        "cakephp/cakephp-codesniffer": "dev-next"
+        "cakephp/cakephp-codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,7 +30,5 @@
         "psr-4": {
             "Josegonzalez\\Upload\\Test\\": "tests"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,19 @@
 parameters:
-    level: 5
+    level: 6
+    checkMissingIterableValueType: false
+    checkGenericClassInNonGenericObjectType: false
     ignoreErrors:
-        - '#Constant ROOT not found#'
-        - '#Constant DS not found#'
+        -
+            message: "#^Constant ROOT not found\\.$#"
+            count: 1
+            path: src/File/Writer/DefaultWriter.php
+
+        -
+            message: "#^Method Josegonzalez\\\\Upload\\\\Model\\\\Behavior\\\\UploadBehavior\\:\\:beforeSave\\(\\) should return void\\|false but return statement is missing\\.$#"
+            count: 1
+            path: src/Model/Behavior/UploadBehavior.php
+
+        -
+            message: "#^Cannot instantiate interface Josegonzalez\\\\Upload\\\\File\\\\Transformer\\\\TransformerInterface\\.$#"
+            count: 1
+            path: src/Model/Behavior/UploadBehavior.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,4 @@ parameters:
     level: 5
     ignoreErrors:
         - '#Constant ROOT not found#'
-        - '#Parameter \#2 \$options of static method Cake\\Utility\\Text::slug\(\) expects array, string given#'
+        - '#Constant DS not found#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
     colors="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="./tests/bootstrap.php"
     >
     <php>

--- a/src/Database/Type/FileType.php
+++ b/src/Database/Type/FileType.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Database\Type;
 
-use Cake\Database\Driver;
-use Cake\Database\Type;
+use Cake\Database\DriverInterface;
+use Cake\Database\Type\BaseType;
 
-class FileType extends Type
+class FileType extends BaseType
 {
     /**
      * Marshalls flat data into PHP objects.
@@ -25,7 +25,7 @@ class FileType extends Type
     /**
      * {@inheritDoc}
      */
-    public function toDatabase($value, Driver $driver)
+    public function toDatabase($value, DriverInterface $driver)
     {
         return $value;
     }
@@ -33,7 +33,7 @@ class FileType extends Type
     /**
      * {@inheritDoc}
      */
-    public function toPHP($value, Driver $driver)
+    public function toPHP($value, DriverInterface $driver)
     {
         return $value;
     }

--- a/src/Database/Type/FileType.php
+++ b/src/Database/Type/FileType.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Database\Type;
 
 use Cake\Database\Driver;

--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Path\Basepath;
 
 use Cake\Utility\Hash;
@@ -12,7 +14,7 @@ trait DefaultTrait
      * the replacement pattern
      *
      * @return string
-     * @throws LogicException if a replacement is not valid for the current dataset
+     * @throws \LogicException if a replacement is not valid for the current dataset
      */
     public function basepath()
     {
@@ -46,11 +48,20 @@ trait DefaultTrait
             foreach ($matches[1] as $field) {
                 $value = $this->entity->get($field);
                 if ($value === null) {
-                    throw new LogicException(sprintf('Field value for substitution is missing: %s', $field));
+                    throw new LogicException(sprintf(
+                        'Field value for substitution is missing: %s',
+                        $field
+                    ));
                 } elseif (!is_scalar($value)) {
-                    throw new LogicException(sprintf('Field value for substitution must be a integer, float, string or boolean: %s', $field));
+                    throw new LogicException(sprintf(
+                        'Field value for substitution must be a integer, float, string or boolean: %s',
+                        $field
+                    ));
                 } elseif (strlen($value) < 1) {
-                    throw new LogicException(sprintf('Field value for substitution must be non-zero in length: %s', $field));
+                    throw new LogicException(sprintf(
+                        'Field value for substitution must be non-zero in length: %s',
+                        $field
+                    ));
                 }
 
                 $replacements[sprintf('{field-value:%s}', $field)] = $value;

--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -16,7 +16,7 @@ trait DefaultTrait
      * @return string
      * @throws \LogicException if a replacement is not valid for the current dataset
      */
-    public function basepath()
+    public function basepath(): string
     {
         $defaultPath = 'webroot{DS}files{DS}{model}{DS}{field}{DS}';
         $path = Hash::get($this->settings, 'path', $defaultPath);

--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -1,11 +1,12 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Path;
 
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Josegonzalez\Upload\File\Path\Basepath\DefaultTrait as BasepathTrait;
 use Josegonzalez\Upload\File\Path\Filename\DefaultTrait as FilenameTrait;
-use Josegonzalez\Upload\File\Path\ProcessorInterface;
 
 class DefaultProcessor implements ProcessorInterface
 {

--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Path;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Josegonzalez\Upload\File\Path\Basepath\DefaultTrait as BasepathTrait;
 use Josegonzalez\Upload\File\Path\Filename\DefaultTrait as FilenameTrait;
@@ -23,7 +23,7 @@ class DefaultProcessor implements ProcessorInterface
     /**
      * Entity instance.
      *
-     * @var \Cake\ORM\Entity
+     * @var \Cake\Datasource\EntityInterface
      */
     protected $entity;
 
@@ -52,12 +52,12 @@ class DefaultProcessor implements ProcessorInterface
      * Constructor
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array|string     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -10,6 +10,9 @@ use Josegonzalez\Upload\File\Path\Filename\DefaultTrait as FilenameTrait;
 
 class DefaultProcessor implements ProcessorInterface
 {
+    use BasepathTrait;
+    use FilenameTrait;
+
     /**
      * Table instance.
      *
@@ -25,9 +28,9 @@ class DefaultProcessor implements ProcessorInterface
     protected $entity;
 
     /**
-     * Array of uploaded data for this field
+     * Array of uploaded data for this field or filename stored in db
      *
-     * @var array
+     * @var array|string
      */
     protected $data;
 
@@ -50,11 +53,11 @@ class DefaultProcessor implements ProcessorInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\ORM\Entity $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param array|string     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings)
+    public function __construct(Table $table, Entity $entity, $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;
@@ -62,7 +65,4 @@ class DefaultProcessor implements ProcessorInterface
         $this->field = $field;
         $this->settings = $settings;
     }
-
-    use BasepathTrait;
-    use FilenameTrait;
 }

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -14,7 +14,7 @@ trait DefaultTrait
      *
      * @return string
      */
-    public function filename()
+    public function filename(): string
     {
         $processor = Hash::get($this->settings, 'nameCallback', null);
         if (is_callable($processor)) {

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Path\Filename;
 
 use Cake\Utility\Hash;

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Path;
 
 use Cake\ORM\Entity;

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Path;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 interface ProcessorInterface
@@ -12,12 +12,12 @@ interface ProcessorInterface
      * Constructor
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array|string     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, $data, string $field, array $settings);
 
     /**
      * Returns the basepath for the current field/data combination

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -13,23 +13,23 @@ interface ProcessorInterface
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
      * @param \Cake\ORM\Entity $entity the entity to construct a path for.
-     * @param array            $data the data being submitted for a save
+     * @param array|string     $data the data being submitted for a save or filename stored in db
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings);
+    public function __construct(Table $table, Entity $entity, $data, string $field, array $settings);
 
     /**
      * Returns the basepath for the current field/data combination
      *
      * @return string
      */
-    public function basepath();
+    public function basepath(): string;
 
     /**
      * Returns the filename for the current field/data combination
      *
      * @return string
      */
-    public function filename();
+    public function filename(): string;
 }

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
-use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 
 class DefaultTransformer implements TransformerInterface
 {

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -52,7 +52,7 @@ class DefaultTransformer implements TransformerInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings)
+    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;
@@ -73,7 +73,7 @@ class DefaultTransformer implements TransformerInterface
      *
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function transform()
+    public function transform(): array
     {
         return [$this->data['tmp_name'] => $this->data['name']];
     }

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Transformer;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 class DefaultTransformer implements TransformerInterface
@@ -18,7 +18,7 @@ class DefaultTransformer implements TransformerInterface
     /**
      * Entity instance.
      *
-     * @var \Cake\ORM\Entity
+     * @var \Cake\Datasource\EntityInterface
      */
     protected $entity;
 
@@ -47,12 +47,12 @@ class DefaultTransformer implements TransformerInterface
      * Constructor
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array            $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Transformer/SlugTransformer.php
+++ b/src/File/Transformer/SlugTransformer.php
@@ -1,8 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\Utility\Text;
-use Josegonzalez\Upload\File\Transformer\DefaultTransformer;
 
 class SlugTransformer extends DefaultTransformer
 {

--- a/src/File/Transformer/SlugTransformer.php
+++ b/src/File/Transformer/SlugTransformer.php
@@ -23,7 +23,7 @@ class SlugTransformer extends DefaultTransformer
      *
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function transform()
+    public function transform(): array
     {
         $filename = pathinfo($this->data['name'], PATHINFO_FILENAME);
         $filename = Text::slug($filename, '-');

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Transformer;
 
 use Cake\ORM\Entity;

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Transformer;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 interface TransformerInterface
@@ -12,12 +12,12 @@ interface TransformerInterface
      * Constructor.
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array            $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings);
 
     /**
      * Creates a set of files from the initial data and returns them as key/value

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -17,7 +17,7 @@ interface TransformerInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings);
+    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings);
 
     /**
      * Creates a set of files from the initial data and returns them as key/value
@@ -31,5 +31,5 @@ interface TransformerInterface
      *
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function transform();
+    public function transform(): array;
 }

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -59,7 +59,7 @@ class DefaultWriter implements WriterInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings)
+    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;
@@ -74,7 +74,7 @@ class DefaultWriter implements WriterInterface
      * @param array $files the files being written out
      * @return array array of results
      */
-    public function write(array $files)
+    public function write(array $files): array
     {
         $filesystem = $this->getFilesystem($this->field, $this->settings);
         $results = [];
@@ -91,7 +91,7 @@ class DefaultWriter implements WriterInterface
      * @param array $files the files being written out
      * @return array array of results
      */
-    public function delete(array $files)
+    public function delete(array $files): array
     {
         $filesystem = $this->getFilesystem($this->field, $this->settings);
         $results = [];
@@ -110,7 +110,7 @@ class DefaultWriter implements WriterInterface
      * @param string $path that path to which the file should be written
      * @return bool
      */
-    public function writeFile(FilesystemInterface $filesystem, $file, $path)
+    public function writeFile(FilesystemInterface $filesystem, $file, $path): bool
     {
         // phpcs:ignore
         $stream = @fopen($file, 'r');
@@ -138,7 +138,7 @@ class DefaultWriter implements WriterInterface
      * @param string $path the path that should be deleted
      * @return bool
      */
-    public function deletePath(FilesystemInterface $filesystem, $path)
+    public function deletePath(FilesystemInterface $filesystem, string $path): bool
     {
         $success = false;
         try {
@@ -157,7 +157,7 @@ class DefaultWriter implements WriterInterface
      * @param array $settings the settings for the current field
      * @return \League\Flysystem\FilesystemInterface
      */
-    public function getFilesystem($field, array $settings = [])
+    public function getFilesystem(string $field, array $settings = []): FilesystemInterface
     {
         $adapter = new Local(Hash::get($settings, 'filesystem.root', ROOT . DS));
         $adapter = Hash::get($settings, 'filesystem.adapter', $adapter);

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -1,12 +1,13 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Writer;
 
 use Cake\ORM\Entity;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
-use Josegonzalez\Upload\File\Writer\WriterInterface;
-use League\Flysystem\AdapterInterface;
 use League\Flysystem\Adapter\Local;
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
@@ -111,6 +112,7 @@ class DefaultWriter implements WriterInterface
      */
     public function writeFile(FilesystemInterface $filesystem, $file, $path)
     {
+        // phpcs:ignore
         $stream = @fopen($file, 'r');
         if ($stream === false) {
             return false;
@@ -165,7 +167,7 @@ class DefaultWriter implements WriterInterface
 
         if ($adapter instanceof AdapterInterface) {
             return new Filesystem($adapter, Hash::get($settings, 'filesystem.options', [
-                'visibility' => AdapterInterface::VISIBILITY_PUBLIC
+                'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
             ]));
         }
 

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Writer;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
 use League\Flysystem\Adapter\Local;
@@ -25,7 +25,7 @@ class DefaultWriter implements WriterInterface
     /**
      * Entity instance.
      *
-     * @var \Cake\ORM\Entity
+     * @var \Cake\Datasource\EntityInterface
      */
     protected $entity;
 
@@ -54,12 +54,12 @@ class DefaultWriter implements WriterInterface
      * Constructs a writer
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array            $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings)
     {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\File\Writer;
 
 use Cake\ORM\Entity;

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -17,7 +17,7 @@ interface WriterInterface
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, $data, $field, $settings);
+    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings);
 
     /**
      * Writes a set of files to an output
@@ -25,7 +25,7 @@ interface WriterInterface
      * @param array $files the files being written out
      * @return array array of results
      */
-    public function write(array $files);
+    public function write(array $files): array;
 
     /**
      * Deletes a set of files to an output
@@ -33,5 +33,5 @@ interface WriterInterface
      * @param array $files the files being written out
      * @return array array of results
      */
-    public function delete(array $files);
+    public function delete(array $files): array;
 }

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\File\Writer;
 
-use Cake\ORM\Entity;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\Table;
 
 interface WriterInterface
@@ -12,12 +12,12 @@ interface WriterInterface
      * Constructor.
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
-     * @param \Cake\ORM\Entity $entity the entity to construct a path for.
+     * @param \Cake\Datasource\EntityInterface $entity the entity to construct a path for.
      * @param array            $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
      */
-    public function __construct(Table $table, Entity $entity, array $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, array $data, string $field, array $settings);
 
     /**
      * Writes a set of files to an output

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -221,8 +221,13 @@ class UploadBehavior extends Behavior
      * @param string $basepath a basepath where the files are written to
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function constructFiles(EntityInterface $entity, array $data, string $field, array $settings, string $basepath): array
-    {
+    public function constructFiles(
+        EntityInterface $entity,
+        array $data,
+        string $field,
+        array $settings,
+        string $basepath
+    ): array {
         $basepath = substr($basepath, -1) == DS ? $basepath : $basepath . DS;
         $transformerClass = Hash::get($settings, 'transformer', DefaultTransformer::class);
         $results = [];

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -26,7 +26,7 @@ class UploadBehavior extends Behavior
      * @param array $config The config for this behavior.
      * @return void
      */
-    public function initialize(array $config)
+    public function initialize(array $config): void
     {
         $configs = [];
         foreach ($config as $field => $settings) {

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -5,9 +5,9 @@ namespace Josegonzalez\Upload\Model\Behavior;
 
 use ArrayObject;
 use Cake\Collection\Collection;
-use Cake\Event\Event;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
 use Cake\ORM\Behavior;
-use Cake\ORM\Entity;
 use Cake\Utility\Hash;
 use Josegonzalez\Upload\File\Path\DefaultProcessor;
 use Josegonzalez\Upload\File\Path\ProcessorInterface;
@@ -53,12 +53,12 @@ class UploadBehavior extends Behavior
     /**
      * Modifies the data being marshalled to ensure invalid upload data is not inserted
      *
-     * @param \Cake\Event\Event $event an event instance
+     * @param \Cake\Event\EventInterface $event an event instance
      * @param \ArrayObject $data data being marshalled
      * @param \ArrayObject $options options for the current event
      * @return void
      */
-    public function beforeMarshal(Event $event, ArrayObject $data, ArrayObject $options)
+    public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options)
     {
         $validator = $this->_table->getValidator();
         $dataArray = $data->getArrayCopy();
@@ -77,12 +77,12 @@ class UploadBehavior extends Behavior
      * Modifies the entity before it is saved so that uploaded file data is persisted
      * in the database too.
      *
-     * @param \Cake\Event\Event $event The beforeSave event that was fired
-     * @param \Cake\ORM\Entity $entity The entity that is going to be saved
+     * @param \Cake\Event\EventInterface $event The beforeSave event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity The entity that is going to be saved
      * @param \ArrayObject $options the options passed to the save method
      * @return void|false
      */
-    public function beforeSave(Event $event, Entity $entity, ArrayObject $options)
+    public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
         foreach ($this->getConfig(null, []) as $field => $settings) {
             if (in_array($field, $this->protectedFieldNames)) {
@@ -122,12 +122,12 @@ class UploadBehavior extends Behavior
     /**
      * Deletes the files after the entity is deleted
      *
-     * @param \Cake\Event\Event $event The afterDelete event that was fired
-     * @param \Cake\ORM\Entity $entity The entity that was deleted
+     * @param \Cake\Event\EventInterface $event The afterDelete event that was fired
+     * @param \Cake\Datasource\EntityInterface $entity The entity that was deleted
      * @param \ArrayObject $options the options passed to the delete method
      * @return bool
      */
-    public function afterDelete(Event $event, Entity $entity, ArrayObject $options)
+    public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options)
     {
         $result = true;
 
@@ -165,13 +165,13 @@ class UploadBehavior extends Behavior
      * Retrieves an instance of a path processor which knows how to build paths
      * for a given file upload
      *
-     * @param \Cake\ORM\Entity $entity an entity
+     * @param \Cake\Datasource\EntityInterface $entity an entity
      * @param array|string $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Path\ProcessorInterface
      */
-    public function getPathProcessor(Entity $entity, $data, string $field, array $settings): ProcessorInterface
+    public function getPathProcessor(EntityInterface $entity, $data, string $field, array $settings): ProcessorInterface
     {
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
 
@@ -181,13 +181,13 @@ class UploadBehavior extends Behavior
     /**
      * Retrieves an instance of a file writer which knows how to write files to disk
      *
-     * @param \Cake\ORM\Entity $entity an entity
+     * @param \Cake\Datasource\EntityInterface $entity an entity
      * @param array $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Writer\WriterInterface
      */
-    public function getWriter(Entity $entity, array $data, string $field, array $settings): WriterInterface
+    public function getWriter(EntityInterface $entity, array $data, string $field, array $settings): WriterInterface
     {
         $writerClass = Hash::get($settings, 'writer', DefaultWriter::class);
 
@@ -209,14 +209,14 @@ class UploadBehavior extends Behavior
      * used to construct this key/value array. This processor can be used to
      * create the source files.
      *
-     * @param \Cake\ORM\Entity $entity an entity
+     * @param \Cake\Datasource\EntityInterface $entity an entity
      * @param array $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @param string $basepath a basepath where the files are written to
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function constructFiles(Entity $entity, array $data, string $field, array $settings, string $basepath): array
+    public function constructFiles(EntityInterface $entity, array $data, string $field, array $settings, string $basepath): array
     {
         $basepath = substr($basepath, -1) == DS ? $basepath : $basepath . DS;
         $transformerClass = Hash::get($settings, 'transformer', DefaultTransformer::class);

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -5,7 +5,6 @@ namespace Josegonzalez\Upload\Model\Behavior;
 
 use ArrayObject;
 use Cake\Collection\Collection;
-use Cake\Database\Type;
 use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
@@ -44,7 +43,6 @@ class UploadBehavior extends Behavior
         $this->setConfig($configs);
         $this->setConfig('className', null);
 
-        Type::map('upload.file', 'Josegonzalez\Upload\Database\Type\FileType');
         $schema = $this->_table->getSchema();
         foreach (array_keys($this->getConfig()) as $field) {
             $schema->setColumnType($field, 'upload.file');

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -10,6 +10,12 @@ use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\Utility\Hash;
+use Josegonzalez\Upload\File\Path\DefaultProcessor;
+use Josegonzalez\Upload\File\Path\ProcessorInterface;
+use Josegonzalez\Upload\File\Transformer\DefaultTransformer;
+use Josegonzalez\Upload\File\Transformer\TransformerInterface;
+use Josegonzalez\Upload\File\Writer\DefaultWriter;
+use Josegonzalez\Upload\File\Writer\WriterInterface;
 use UnexpectedValueException;
 
 class UploadBehavior extends Behavior
@@ -162,23 +168,16 @@ class UploadBehavior extends Behavior
      * for a given file upload
      *
      * @param \Cake\ORM\Entity $entity an entity
-     * @param array $data the data being submitted for a save
+     * @param array|string $data the data being submitted for a save
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Path\ProcessorInterface
      */
-    public function getPathProcessor(Entity $entity, $data, $field, $settings)
+    public function getPathProcessor(Entity $entity, $data, string $field, array $settings): ProcessorInterface
     {
-        $default = 'Josegonzalez\Upload\File\Path\DefaultProcessor';
-        $processorClass = Hash::get($settings, 'pathProcessor', $default);
-        if (is_subclass_of($processorClass, 'Josegonzalez\Upload\File\Path\ProcessorInterface')) {
-            return new $processorClass($this->_table, $entity, $data, $field, $settings);
-        }
+        $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
 
-        throw new UnexpectedValueException(sprintf(
-            "'pathProcessor' not set to instance of ProcessorInterface: %s",
-            $processorClass
-        ));
+        return new $processorClass($this->_table, $entity, $data, $field, $settings);
     }
 
     /**
@@ -190,18 +189,11 @@ class UploadBehavior extends Behavior
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Writer\WriterInterface
      */
-    public function getWriter(Entity $entity, $data, $field, $settings)
+    public function getWriter(Entity $entity, array $data, string $field, array $settings): WriterInterface
     {
-        $default = 'Josegonzalez\Upload\File\Writer\DefaultWriter';
-        $writerClass = Hash::get($settings, 'writer', $default);
-        if (is_subclass_of($writerClass, 'Josegonzalez\Upload\File\Writer\WriterInterface')) {
-            return new $writerClass($this->_table, $entity, $data, $field, $settings);
-        }
+        $writerClass = Hash::get($settings, 'writer', DefaultWriter::class);
 
-        throw new UnexpectedValueException(sprintf(
-            "'writer' not set to instance of WriterInterface: %s",
-            $writerClass
-        ));
+        return new $writerClass($this->_table, $entity, $data, $field, $settings);
     }
 
     /**
@@ -226,13 +218,12 @@ class UploadBehavior extends Behavior
      * @param string $basepath a basepath where the files are written to
      * @return array key/value pairs of temp files mapping to their names
      */
-    public function constructFiles(Entity $entity, $data, $field, $settings, $basepath)
+    public function constructFiles(Entity $entity, array $data, string $field, array $settings, string $basepath): array
     {
         $basepath = substr($basepath, -1) == DS ? $basepath : $basepath . DS;
-        $default = 'Josegonzalez\Upload\File\Transformer\DefaultTransformer';
-        $transformerClass = Hash::get($settings, 'transformer', $default);
+        $transformerClass = Hash::get($settings, 'transformer', DefaultTransformer::class);
         $results = [];
-        if (is_subclass_of($transformerClass, 'Josegonzalez\Upload\File\Transformer\TransformerInterface')) {
+        if (is_subclass_of($transformerClass, TransformerInterface::class)) {
             $transformer = new $transformerClass($this->_table, $entity, $data, $field, $settings);
             $results = $transformer->transform();
             foreach ($results as $key => $value) {

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -19,6 +19,11 @@ use UnexpectedValueException;
 
 class UploadBehavior extends Behavior
 {
+    /**
+     * Protected file names
+     *
+     * @var array
+     */
     private $protectedFieldNames = [
         'priority',
     ];

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Model\Behavior;
 
 use ArrayObject;
@@ -8,10 +10,6 @@ use Cake\Event\Event;
 use Cake\ORM\Behavior;
 use Cake\ORM\Entity;
 use Cake\Utility\Hash;
-use Exception;
-use Josegonzalez\Upload\File\Path\DefaultProcessor;
-use Josegonzalez\Upload\File\Transformer\DefaultTransformer;
-use Josegonzalez\Upload\File\Writer\DefaultWriter;
 use UnexpectedValueException;
 
 class UploadBehavior extends Behavior
@@ -230,7 +228,7 @@ class UploadBehavior extends Behavior
      */
     public function constructFiles(Entity $entity, $data, $field, $settings, $basepath)
     {
-        $basepath = (substr($basepath, -1) == DS ? $basepath : $basepath . DS);
+        $basepath = substr($basepath, -1) == DS ? $basepath : $basepath . DS;
         $default = 'Josegonzalez\Upload\File\Transformer\DefaultTransformer';
         $transformerClass = Hash::get($settings, 'transformer', $default);
         $results = [];

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,10 +4,17 @@ declare(strict_types=1);
 namespace Josegonzalez\Upload;
 
 use Cake\Core\BasePlugin;
+use Cake\Core\PluginApplicationInterface;
+use Cake\Database\TypeFactory;
+use Josegonzalez\Upload\Database\Type\FileType;
 
 /**
- * Plugin class for CakePHP 3.6.0 plugin collection.
+ * Plugin class.
  */
 class Plugin extends BasePlugin
 {
+    public function bootstrap(PluginApplicationInterface $app): void
+    {
+        TypeFactory::map('upload.file', FileType::class);
+    }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,12 @@ use Josegonzalez\Upload\Database\Type\FileType;
  */
 class Plugin extends BasePlugin
 {
+    /**
+     * Plugin bootstrap.
+     *
+     * @param \Cake\Core\PluginApplicationInterface $app Application instance.
+     * @return void
+     */
     public function bootstrap(PluginApplicationInterface $app): void
     {
         TypeFactory::map('upload.file', FileType::class);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload;
 

--- a/src/Validation/DefaultValidation.php
+++ b/src/Validation/DefaultValidation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation;
 

--- a/src/Validation/ImageValidation.php
+++ b/src/Validation/ImageValidation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation;
 

--- a/src/Validation/Traits/ImageValidationTrait.php
+++ b/src/Validation/Traits/ImageValidationTrait.php
@@ -12,7 +12,7 @@ trait ImageValidationTrait
      * @param int $width Width of Image
      * @return bool Success
      */
-    public static function isAboveMinWidth($check, $width)
+    public static function isAboveMinWidth($check, int $width): bool
     {
         // Non-file uploads also mean the height is too big
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
@@ -30,7 +30,7 @@ trait ImageValidationTrait
      * @param int $width Width of Image
      * @return bool Success
      */
-    public static function isBelowMaxWidth($check, $width)
+    public static function isBelowMaxWidth($check, int $width): bool
     {
         // Non-file uploads also mean the height is too big
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
@@ -48,7 +48,7 @@ trait ImageValidationTrait
      * @param int $height Height of Image
      * @return bool Success
      */
-    public static function isAboveMinHeight($check, $height)
+    public static function isAboveMinHeight($check, int $height): bool
     {
         // Non-file uploads also mean the height is too big
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
@@ -66,7 +66,7 @@ trait ImageValidationTrait
      * @param int $height Height of Image
      * @return bool Success
      */
-    public static function isBelowMaxHeight($check, $height)
+    public static function isBelowMaxHeight($check, int $height): bool
     {
         // Non-file uploads also mean the height is too big
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {

--- a/src/Validation/Traits/ImageValidationTrait.php
+++ b/src/Validation/Traits/ImageValidationTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation\Traits;
 
@@ -17,7 +18,7 @@ trait ImageValidationTrait
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
             return false;
         }
-        list($imgWidth) = getimagesize($check['tmp_name']);
+        [$imgWidth] = getimagesize($check['tmp_name']);
 
         return $width > 0 && $imgWidth >= $width;
     }
@@ -35,7 +36,7 @@ trait ImageValidationTrait
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
             return false;
         }
-        list($imgWidth) = getimagesize($check['tmp_name']);
+        [$imgWidth] = getimagesize($check['tmp_name']);
 
         return $width > 0 && $imgWidth <= $width;
     }
@@ -53,7 +54,7 @@ trait ImageValidationTrait
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
             return false;
         }
-        list(, $imgHeight) = getimagesize($check['tmp_name']);
+        [, $imgHeight] = getimagesize($check['tmp_name']);
 
         return $height > 0 && $imgHeight >= $height;
     }
@@ -71,7 +72,7 @@ trait ImageValidationTrait
         if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
             return false;
         }
-        list(, $imgHeight) = getimagesize($check['tmp_name']);
+        [, $imgHeight] = getimagesize($check['tmp_name']);
 
         return $height > 0 && $imgHeight <= $height;
     }

--- a/src/Validation/Traits/UploadValidationTrait.php
+++ b/src/Validation/Traits/UploadValidationTrait.php
@@ -14,7 +14,7 @@ trait UploadValidationTrait
      * @param mixed $check Value to check
      * @return bool Success
      */
-    public static function isUnderPhpSizeLimit($check)
+    public static function isUnderPhpSizeLimit($check): bool
     {
         return Hash::get($check, 'error') !== UPLOAD_ERR_INI_SIZE;
     }
@@ -26,7 +26,7 @@ trait UploadValidationTrait
      * @param mixed $check Value to check
      * @return bool Success
      */
-    public static function isUnderFormSizeLimit($check)
+    public static function isUnderFormSizeLimit($check): bool
     {
         return Hash::get($check, 'error') !== UPLOAD_ERR_FORM_SIZE;
     }
@@ -37,7 +37,7 @@ trait UploadValidationTrait
      * @param mixed $check Value to check
      * @return bool Success
      */
-    public static function isCompletedUpload($check)
+    public static function isCompletedUpload($check): bool
     {
         return Hash::get($check, 'error') !== UPLOAD_ERR_PARTIAL;
     }
@@ -48,7 +48,7 @@ trait UploadValidationTrait
      * @param mixed $check Value to check
      * @return bool Success
      */
-    public static function isFileUpload($check)
+    public static function isFileUpload($check): bool
     {
         return Hash::get($check, 'error') !== UPLOAD_ERR_NO_FILE;
     }
@@ -59,7 +59,7 @@ trait UploadValidationTrait
      * @param mixed $check Value to check
      * @return bool Success
      */
-    public static function isSuccessfulWrite($check)
+    public static function isSuccessfulWrite($check): bool
     {
         return Hash::get($check, 'error') !== UPLOAD_ERR_CANT_WRITE;
     }
@@ -71,7 +71,7 @@ trait UploadValidationTrait
      * @param int $size Minimum file size
      * @return bool Success
      */
-    public static function isAboveMinSize($check, $size)
+    public static function isAboveMinSize($check, $size): bool
     {
         return !empty($check['size']) && $check['size'] >= $size;
     }
@@ -83,7 +83,7 @@ trait UploadValidationTrait
      * @param int $size Maximum file size
      * @return bool Success
      */
-    public static function isBelowMaxSize($check, $size)
+    public static function isBelowMaxSize($check, $size): bool
     {
         return !empty($check['size']) && $check['size'] <= $size;
     }

--- a/src/Validation/Traits/UploadValidationTrait.php
+++ b/src/Validation/Traits/UploadValidationTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation\Traits;
 
@@ -72,12 +73,7 @@ trait UploadValidationTrait
      */
     public static function isAboveMinSize($check, $size)
     {
-        // Non-file uploads also mean the size is too small
-        if (!isset($check['size']) || !strlen($check['size'])) {
-            return false;
-        }
-
-        return $check['size'] >= $size;
+        return !empty($check['size']) && $check['size'] >= $size;
     }
 
     /**
@@ -89,11 +85,6 @@ trait UploadValidationTrait
      */
     public static function isBelowMaxSize($check, $size)
     {
-        // Non-file uploads also mean the size is too small
-        if (!isset($check['size']) || !strlen($check['size'])) {
-            return false;
-        }
-
-        return $check['size'] <= $size;
+        return !empty($check['size']) && $check['size'] <= $size;
     }
 }

--- a/src/Validation/UploadValidation.php
+++ b/src/Validation/UploadValidation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation;
 

--- a/tests/Fixture/FilesFixture.php
+++ b/tests/Fixture/FilesFixture.php
@@ -30,7 +30,7 @@ class FilesFixture extends TestFixture
         ['filename' => 'FileThree'],
     ];
 
-    public function init()
+    public function init(): void
     {
         $created = $modified = date('Y-m-d H:i:s');
         array_walk($this->records, function (&$record) use ($created, $modified) {

--- a/tests/Fixture/FilesFixture.php
+++ b/tests/Fixture/FilesFixture.php
@@ -16,7 +16,7 @@ class FilesFixture extends TestFixture
         'id' => ['type' => 'integer'],
         'filename' => ['type' => 'string'],
         'created' => ['type' => 'datetime', 'null' => true],
-        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]]
+        '_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
     ];
 
     /**

--- a/tests/Stub/ChildBehavior.php
+++ b/tests/Stub/ChildBehavior.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\Stub;
 
 use Josegonzalez\Upload\Model\Behavior\UploadBehavior;

--- a/tests/TestCase/Database/Type/FileTypeTest.php
+++ b/tests/TestCase/Database/Type/FileTypeTest.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\Database\Type;
 
 use Cake\TestSuite\TestCase;

--- a/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Basepath/DefaultTraitTest.php
@@ -1,10 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Path\Basepath;
 
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
-use Josegonzalez\Upload\File\Path\Basepath\DefaultTrait;
 
 class DefaultTraitTest extends TestCase
 {

--- a/tests/TestCase/File/Path/DefaultProcessorTest.php
+++ b/tests/TestCase/File/Path/DefaultProcessorTest.php
@@ -1,9 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Path;
 
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\File\Path\DefaultProcessor;
-use Josegonzalez\Upload\File\Path\ProcessorInterface;
 
 class DefaultProcessorTest extends TestCase
 {

--- a/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
@@ -1,8 +1,9 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Path\Filename;
 
 use Cake\TestSuite\TestCase;
-use Josegonzalez\Upload\File\Path\Filename\DefaultTrait;
 
 class DefaultTraitTest extends TestCase
 {

--- a/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
@@ -26,11 +26,11 @@ class DefaultTraitTest extends TestCase
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->settings = [
             'nameCallback' => function ($data, $settings) {
-                return $data;
+                return $data['name'];
             },
         ];
         $mock->data = ['name' => 'filename'];
-        $this->assertEquals(['name' => 'filename'], $mock->filename());
+        $this->assertEquals('filename', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
@@ -38,10 +38,10 @@ class DefaultTraitTest extends TestCase
         $mock->field = 'field';
         $mock->settings = [
             'nameCallback' => function ($table, $entity, $data, $field, $settings) {
-                return $data;
+                return $data['name'];
             },
         ];
         $mock->data = ['name' => 'filename'];
-        $this->assertEquals(['name' => 'filename'], $mock->filename());
+        $this->assertEquals('filename', $mock->filename());
     }
 }

--- a/tests/TestCase/File/Transformer/DefaultTransformerTest.php
+++ b/tests/TestCase/File/Transformer/DefaultTransformerTest.php
@@ -1,11 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Transformer;
 
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\File\Transformer\DefaultTransformer;
-use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 
 class DefaultTransformerTest extends TestCase
 {

--- a/tests/TestCase/File/Transformer/DefaultTransformerTest.php
+++ b/tests/TestCase/File/Transformer/DefaultTransformerTest.php
@@ -9,7 +9,7 @@ use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 
 class DefaultTransformerTest extends TestCase
 {
-    public function setup()
+    public function setUp(): void
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
@@ -17,11 +17,6 @@ class DefaultTransformerTest extends TestCase
         $field = 'field';
         $settings = [];
         $this->transformer = new DefaultTransformer($table, $entity, $data, $field, $settings);
-    }
-
-    public function teardown()
-    {
-        unset($this->transformer);
     }
 
     public function testIsProcessorInterface()

--- a/tests/TestCase/File/Transformer/SlugTransformerTest.php
+++ b/tests/TestCase/File/Transformer/SlugTransformerTest.php
@@ -1,11 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Transformer;
 
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\File\Transformer\SlugTransformer;
-use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 
 class SlugTransformerTest extends TestCase
 {

--- a/tests/TestCase/File/Transformer/SlugTransformerTest.php
+++ b/tests/TestCase/File/Transformer/SlugTransformerTest.php
@@ -9,7 +9,7 @@ use Josegonzalez\Upload\File\Transformer\TransformerInterface;
 
 class SlugTransformerTest extends TestCase
 {
-    public function setup()
+    public function setUp(): void
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
@@ -17,11 +17,6 @@ class SlugTransformerTest extends TestCase
         $field = 'field';
         $settings = [];
         $this->transformer = new SlugTransformer($table, $entity, $data, $field, $settings);
-    }
-
-    public function teardown()
-    {
-        unset($this->transformer);
     }
 
     public function testTransform()

--- a/tests/TestCase/File/Writer/DefaultWriterTest.php
+++ b/tests/TestCase/File/Writer/DefaultWriterTest.php
@@ -20,7 +20,7 @@ class DefaultWriterTest extends TestCase
     protected $field;
     protected $settings;
 
-    public function setup()
+    public function setUp(): void
     {
         $this->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $this->table = $this->getMockBuilder('Cake\ORM\Table')->getMock();

--- a/tests/TestCase/File/Writer/DefaultWriterTest.php
+++ b/tests/TestCase/File/Writer/DefaultWriterTest.php
@@ -1,12 +1,11 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\File\Writer;
 
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\File\Writer\DefaultWriter;
 use League\Flysystem\Adapter\NullAdapter;
-use League\Flysystem\FilesystemInterface;
 use League\Flysystem\Vfs\VfsAdapter;
 use VirtualFileSystem\FileSystem as Vfs;
 
@@ -29,9 +28,9 @@ class DefaultWriterTest extends TestCase
         $this->settings = [
             'filesystem' => [
                 'adapter' => function () {
-                    return new VfsAdapter(new Vfs);
-                }
-            ]
+                    return new VfsAdapter(new Vfs());
+                },
+            ],
         ];
         $this->writer = new DefaultWriter(
             $this->table,
@@ -41,7 +40,7 @@ class DefaultWriterTest extends TestCase
             $this->settings
         );
 
-        $this->vfs = new Vfs;
+        $this->vfs = new Vfs();
         mkdir($this->vfs->path('/tmp'));
         file_put_contents($this->vfs->path('/tmp/tempfile'), 'content');
     }
@@ -55,11 +54,11 @@ class DefaultWriterTest extends TestCase
     {
         $this->assertEquals([], $this->writer->write([]));
         $this->assertEquals([true], $this->writer->write([
-            $this->vfs->path('/tmp/tempfile') => 'file.txt'
+            $this->vfs->path('/tmp/tempfile') => 'file.txt',
         ], 'field', []));
 
         $this->assertEquals([false], $this->writer->write([
-            $this->vfs->path('/tmp/invalid.txt') => 'file.txt'
+            $this->vfs->path('/tmp/invalid.txt') => 'file.txt',
         ], 'field', []));
     }
 
@@ -76,11 +75,11 @@ class DefaultWriterTest extends TestCase
 
         $this->assertEquals([], $writer->delete([]));
         $this->assertEquals([true], $writer->delete([
-            $this->vfs->path('/tmp/tempfile')
+            $this->vfs->path('/tmp/tempfile'),
         ]));
 
         $this->assertEquals([false], $writer->delete([
-            $this->vfs->path('/tmp/invalid.txt')
+            $this->vfs->path('/tmp/invalid.txt'),
         ]));
     }
 
@@ -120,19 +119,19 @@ class DefaultWriterTest extends TestCase
     {
         $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->writer->getFilesystem('field', []));
         $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->writer->getFilesystem('field', [
-            'key' => 'value'
+            'key' => 'value',
         ]));
         $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->writer->getFilesystem('field', [
             'filesystem' => [
-                'adapter' => new NullAdapter
-            ]
+                'adapter' => new NullAdapter(),
+            ],
         ]));
         $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->writer->getFilesystem('field', [
             'filesystem' => [
                 'adapter' => function () {
-                    return new NullAdapter;
+                    return new NullAdapter();
                 },
-            ]
+            ],
         ]));
     }
 
@@ -142,8 +141,8 @@ class DefaultWriterTest extends TestCase
 
         $this->writer->getFilesystem('field', [
             'filesystem' => [
-                'adapter' => 'invalid_adapter'
-            ]
+                'adapter' => 'invalid_adapter',
+            ],
         ]);
     }
 }

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -17,7 +17,7 @@ class UploadBehaviorTest extends TestCase
         'plugin.Josegonzalez/Upload.Files',
     ];
 
-    public function setup()
+    public function setUp(): void
     {
         $this->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $this->table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
@@ -59,9 +59,9 @@ class UploadBehaviorTest extends TestCase
     public function testInitialize()
     {
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
-        $schema = $this->getMockBuilder('Cake\Database\Schema\Table')
-            ->setMethods([])
-            ->setConstructorArgs([$table, []])
+        $schema = $this->getMockBuilder('Cake\Database\Schema\TableSchema')
+            ->setMethods(['setColumnType', 'getSchema', 'setSchema'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schema->expects($this->once())
                     ->method('setColumnType')
@@ -104,9 +104,9 @@ class UploadBehaviorTest extends TestCase
     {
         $settings = ['field'];
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
-        $schema = $this->getMockBuilder('Cake\Database\Schema\Table')
-            ->setMethods([])
-            ->setConstructorArgs([$table, []])
+        $schema = $this->getMockBuilder('Cake\Database\Schema\TableSchema')
+            ->setMethods(['setColumnType', 'getSchema', 'setSchema'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schema->expects($this->once())
                ->method('setColumnType')
@@ -139,9 +139,9 @@ class UploadBehaviorTest extends TestCase
             'field' => []
         ];
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
-        $schema = $this->getMockBuilder('Cake\Database\Schema\Table')
-            ->setMethods([])
-            ->setConstructorArgs([$table, []])
+        $schema = $this->getMockBuilder('Cake\Database\Schema\TableSchema')
+            ->setMethods(['setColumnType', 'getSchema', 'setSchema'])
+            ->disableOriginalConstructor()
             ->getMock();
         $schema->expects($this->once())
             ->method('setColumnType')

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -1,10 +1,10 @@
 <?php
+declare(strict_types=1);
+
 namespace Josegonzalez\Upload\Test\TestCase\Model\Behavior;
 
 use ArrayObject;
 use Cake\Event\Event;
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\Model\Behavior\UploadBehavior;
@@ -29,8 +29,8 @@ class UploadBehaviorTest extends TestCase
                 'size' => 1,
                 'type' => 'text',
                 'keepFilesOnDelete' => false,
-                'deleteCallback' => null
-            ]
+                'deleteCallback' => null,
+            ],
         ];
         $this->dataError = [
             'field' => [
@@ -39,7 +39,7 @@ class UploadBehaviorTest extends TestCase
                 'error' => UPLOAD_ERR_NO_FILE,
                 'size' => 0,
                 'type' => '',
-            ]
+            ],
         ];
         $this->field = 'field';
         $this->settings = ['field' => []];
@@ -136,7 +136,7 @@ class UploadBehaviorTest extends TestCase
     {
         $settings = [
             'className' => 'Josegonzalez\Upload\Model\Behavior\UploadBehavior',
-            'field' => []
+            'field' => [],
         ];
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $schema = $this->getMockBuilder('Cake\Database\Schema\TableSchema')
@@ -191,7 +191,7 @@ class UploadBehaviorTest extends TestCase
                  ->will($this->returnValue($this->settings));
 
         $data = new ArrayObject($this->dataOk);
-        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject);
+        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
         $this->assertEquals(new ArrayObject($this->dataOk), $data);
     }
 
@@ -217,8 +217,8 @@ class UploadBehaviorTest extends TestCase
                  ->will($this->returnValue($this->settings));
 
         $data = new ArrayObject($this->dataError);
-        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject);
-        $this->assertEquals(new ArrayObject, $data);
+        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
+        $this->assertEquals(new ArrayObject(), $data);
     }
 
     public function testBeforeMarshalEmptyAllowed()
@@ -243,7 +243,7 @@ class UploadBehaviorTest extends TestCase
                  ->will($this->returnValue($this->settings));
 
         $data = new ArrayObject($this->dataError);
-        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject);
+        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
         $this->assertEquals(new ArrayObject($this->dataError), $data);
     }
 
@@ -275,7 +275,7 @@ class UploadBehaviorTest extends TestCase
         $this->entity->expects($this->once())
             ->method('setDirty')
             ->with('field', false);
-        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testBeforeSaveWriteFail()
@@ -303,12 +303,12 @@ class UploadBehaviorTest extends TestCase
                      ->method('write')
                      ->will($this->returnValue([false]));
 
-        $this->assertFalse($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertFalse($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testBeforeSaveOk()
     {
-        $methods = array_diff($this->behaviorMethods, ['beforeSave', 'config', 'setConfig', 'getConfig']);
+        $methods = array_diff($this->behaviorMethods, ['beforeSave', 'setConfig', 'getConfig']);
         $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
             ->setMethods($methods)
             ->setConstructorArgs([$this->table, $this->settings])
@@ -327,11 +327,14 @@ class UploadBehaviorTest extends TestCase
         $behavior->expects($this->any())
                  ->method('constructFiles')
                  ->will($this->returnValue([]));
+        $this->processor->expects($this->any())
+                ->method('filename')
+                ->will($this->returnValue('derp'));
         $this->writer->expects($this->any())
                      ->method('write')
                      ->will($this->returnValue([true]));
 
-        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testBeforeSaveDoesNotRestoreOriginalValue()
@@ -348,7 +351,7 @@ class UploadBehaviorTest extends TestCase
         $this->entity->expects($this->never())->method('getOriginal');
         $this->entity->expects($this->never())->method('set');
 
-        $behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject);
+        $behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject());
     }
 
     public function testBeforeSaveWithProtectedFieldName()
@@ -363,7 +366,7 @@ class UploadBehaviorTest extends TestCase
             ->getMock();
         $behavior->setConfig($settings);
 
-        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testAfterDeleteOk()
@@ -385,7 +388,7 @@ class UploadBehaviorTest extends TestCase
                      ->method('delete')
                      ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testAfterDeleteFail()
@@ -407,7 +410,7 @@ class UploadBehaviorTest extends TestCase
                      ->method('delete')
                      ->will($this->returnValue([false]));
 
-        $this->assertFalse($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertFalse($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testAfterDeleteSkip()
@@ -426,7 +429,7 @@ class UploadBehaviorTest extends TestCase
             ->method('delete')
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testAfterDeleteUsesPathProcessorToDetectPathToTheFile()
@@ -474,7 +477,7 @@ class UploadBehaviorTest extends TestCase
             ->with([$dir . $field])
             ->willReturn([true]);
 
-        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject);
+        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject());
     }
 
     public function testAfterDeletePrefersStoredPathOverPathProcessor()
@@ -513,7 +516,7 @@ class UploadBehaviorTest extends TestCase
             ->with([$dir . $field])
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testAfterDeleteNoDeleteCallback()
@@ -540,11 +543,11 @@ class UploadBehaviorTest extends TestCase
         $this->writer->expects($this->once())
             ->method('delete')
             ->with([
-                $path . $this->entity->field
+                $path . $this->entity->field,
             ])
             ->willReturn([true, true, true]);
 
-        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject);
+        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject());
     }
 
     public function testAfterDeleteUsesDeleteCallback()
@@ -561,7 +564,7 @@ class UploadBehaviorTest extends TestCase
             return [
                 $path . $entity->{$field},
                 $path . 'sm-' . $entity->{$field},
-                $path . 'lg-' . $entity->{$field}
+                $path . 'lg-' . $entity->{$field},
             ];
         };
 
@@ -579,11 +582,11 @@ class UploadBehaviorTest extends TestCase
             ->with([
                 $path . $this->entity->field,
                 $path . 'sm-' . $this->entity->field,
-                $path . 'lg-' . $this->entity->field
+                $path . 'lg-' . $this->entity->field,
             ])
             ->willReturn([true, true, true]);
 
-        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject);
+        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject());
     }
 
     public function testAfterDeleteWithProtectedFieldName()
@@ -604,7 +607,7 @@ class UploadBehaviorTest extends TestCase
             ->method('delete')
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject));
+        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testGetWriter()

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -616,12 +616,6 @@ class UploadBehaviorTest extends TestCase
         $this->assertInstanceOf('Josegonzalez\Upload\File\Writer\WriterInterface', $processor);
     }
 
-    public function testGetWriterException()
-    {
-        $this->expectException('UnexpectedValueException', "'writer' not set to instance of WriterInterface: UnexpectedValueException");
-        $this->behavior->getWriter($this->entity, [], 'field', ['writer' => 'UnexpectedValueException']);
-    }
-
     public function testConstructFiles()
     {
         $files = $this->behavior->constructFiles(
@@ -710,11 +704,5 @@ class UploadBehaviorTest extends TestCase
     {
         $processor = $this->behavior->getPathProcessor($this->entity, [], 'field', []);
         $this->assertInstanceOf('Josegonzalez\Upload\File\Path\ProcessorInterface', $processor);
-    }
-
-    public function testGetPathProcessorException()
-    {
-        $this->expectException('UnexpectedValueException', "'pathProcessor' not set to instance of ProcessorInterface: UnexpectedValueException");
-        $this->behavior->getPathProcessor($this->entity, [], 'field', ['pathProcessor' => 'UnexpectedValueException']);
     }
 }

--- a/tests/TestCase/Validation/ImageValidationTest.php
+++ b/tests/TestCase/Validation/ImageValidationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Test\TestCase\Validation;
 
@@ -15,7 +16,7 @@ class ImageValidationTest extends TestCase
     {
         parent::setUp();
 
-        $this->vfs = new Vfs;
+        $this->vfs = new Vfs();
         mkdir($this->vfs->path('/tmp'));
 
         // Write sample image with dimensions: 20x20
@@ -28,7 +29,7 @@ class ImageValidationTest extends TestCase
             'type' => 'text/plain',
             'tmp_name' => $this->vfs->path('/tmp/tmpimage'),
             'size' => 200,
-            'error' => UPLOAD_ERR_OK
+            'error' => UPLOAD_ERR_OK,
         ];
     }
 

--- a/tests/TestCase/Validation/ImageValidationTest.php
+++ b/tests/TestCase/Validation/ImageValidationTest.php
@@ -11,7 +11,7 @@ class ImageValidationTest extends TestCase
     private $data;
     private $vfs;
 
-    public function setup()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -30,11 +30,6 @@ class ImageValidationTest extends TestCase
             'size' => 200,
             'error' => UPLOAD_ERR_OK
         ];
-    }
-
-    public function teardown()
-    {
-        parent::tearDown();
     }
 
     public function testIsAboveMinWidth()

--- a/tests/TestCase/Validation/UploadValidationTest.php
+++ b/tests/TestCase/Validation/UploadValidationTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Test\TestCase\Validation;
 
@@ -16,7 +17,7 @@ class UploadValidationTest extends TestCase
             'name' => 'sample.txt',
             'type' => 'text/plain',
             'tmp_name' => '/tmp/tmpfile',
-            'size' => 200
+            'size' => 200,
         ];
     }
 

--- a/tests/TestCase/Validation/UploadValidationTest.php
+++ b/tests/TestCase/Validation/UploadValidationTest.php
@@ -9,7 +9,7 @@ class UploadValidationTest extends TestCase
 {
     private $data;
 
-    public function setup()
+    public function setUp(): void
     {
         parent::setUp();
         $this->data = [
@@ -18,11 +18,6 @@ class UploadValidationTest extends TestCase
             'tmp_name' => '/tmp/tmpfile',
             'size' => 200
         ];
-    }
-
-    public function teardown()
-    {
-        parent::tearDown();
     }
 
     public function testIsUnderPhpSizeLimit()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /*
  * Test suite bootstrap
  *


### PR DESCRIPTION
If you're creating a new entity and not uploading a file, or editing and not replacing the file upload then an upload error should not be triggered, but the entity should be saved.