### PR TITLE
Allow entity to contain an non-updated file upload.

### DIFF
--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -57,7 +57,7 @@ trait DefaultTrait
                         'Field value for substitution must be a integer, float, string or boolean: %s',
                         $field
                     ));
-                } elseif (strlen($value) < 1) {
+                } elseif (strlen((string)$value) < 1) {
                     throw new LogicException(sprintf(
                         'Field value for substitution must be non-zero in length: %s',
                         $field

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -69,7 +69,10 @@ class UploadBehavior extends Behavior
         $validator = $this->_table->getValidator();
         $dataArray = $data->getArrayCopy();
         foreach (array_keys($this->getConfig(null, [])) as $field) {
-            if (!$validator->isEmptyAllowed($field, false) || $dataArray[$field]->getError() !== UPLOAD_ERR_NO_FILE) {
+            if (!$validator->isEmptyAllowed($field, false)) {
+                continue;
+            }
+            if (!empty($dataArray[$field]) && $dataArray[$field]->getError() !== UPLOAD_ERR_NO_FILE) {
                 continue;
             }
             unset($data[$field]);
@@ -92,7 +95,7 @@ class UploadBehavior extends Behavior
                 continue;
             }
 
-            if (empty($entity->get($field))) {
+            if (empty($entity->get($field)) || !$entity->isDirty($field)) {
                 continue;
             }
 

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -69,11 +69,7 @@ class UploadBehavior extends Behavior
         $validator = $this->_table->getValidator();
         $dataArray = $data->getArrayCopy();
         foreach (array_keys($this->getConfig(null, [])) as $field) {
-            if (!$validator->isEmptyAllowed($field, false)) {
-                continue;
-            }
-
-            if ($dataArray[$field]->getError() !== UPLOAD_ERR_NO_FILE) {
+            if (!$validator->isEmptyAllowed($field, false) || $dataArray[$field]->getError() !== UPLOAD_ERR_NO_FILE) {
                 continue;
             }
             unset($data[$field]);

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -255,7 +255,7 @@ class UploadBehaviorTest extends TestCase
         $this->assertEquals(new ArrayObject($this->dataError), $data);
     }
 
-    public function testBeforeSaveUploadError()
+    public function testBeforeSaveNoUpload()
     {
         $originalValue = rand(1000, 9999);
 
@@ -277,16 +277,16 @@ class UploadBehaviorTest extends TestCase
             ->method('getOriginal')
             ->with('field')
             ->will($this->returnValue($originalValue));
-        $this->entity->expects($this->once())
+        $this->entity->expects($this->never())
             ->method('set')
             ->with('field', $originalValue);
-        $this->entity->expects($this->once())
+        $this->entity->expects($this->never())
             ->method('setDirty')
             ->with('field', false);
         $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
-    public function testBeforeSaveWriteFail()
+    public function testBeforeSaveNoWrite()
     {
         $methods = array_diff($this->behaviorMethods, ['beforeSave', 'setConfig', 'getConfig']);
         $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
@@ -311,7 +311,7 @@ class UploadBehaviorTest extends TestCase
                      ->method('write')
                      ->will($this->returnValue([false]));
 
-        $this->assertFalse($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $this->assertNull($behavior->beforeSave(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
     public function testBeforeSaveOk()


### PR DESCRIPTION
If you're creating a new entity and not uploading a file, or editing and not replacing the file upload then an upload error should not be triggered, but the entity should be saved.