### PR TITLE
[cake-4.x] nameCallback filename is not used.

### DIFF
--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -45,6 +45,13 @@ class DefaultTransformer implements TransformerInterface
     protected $settings;
 
     /**
+     * Processor to get filename from
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
      * Constructor
      *
      * @param \Cake\ORM\Table  $table the instance managing the entity
@@ -52,14 +59,16 @@ class DefaultTransformer implements TransformerInterface
      * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
+     * @param string           $filename from the processor to use
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings)
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings, string $filename)
     {
         $this->table = $table;
         $this->entity = $entity;
         $this->data = $data;
         $this->field = $field;
         $this->settings = $settings;
+        $this->filename = $filename;
     }
 
     /**
@@ -76,6 +85,6 @@ class DefaultTransformer implements TransformerInterface
      */
     public function transform(): array
     {
-        return [$this->data->getStream()->getMetadata('uri') => $this->data->getClientFileName()];
+        return [$this->data->getStream()->getMetadata('uri') => $this->filename];
     }
 }

--- a/src/File/Transformer/SlugTransformer.php
+++ b/src/File/Transformer/SlugTransformer.php
@@ -25,10 +25,10 @@ class SlugTransformer extends DefaultTransformer
      */
     public function transform(): array
     {
-        $filename = pathinfo($this->data->getClientFilename(), PATHINFO_FILENAME);
+        $filename = pathinfo($this->filename, PATHINFO_FILENAME);
         $filename = Text::slug($filename, '-');
 
-        $ext = pathinfo($this->data->getClientFilename(), PATHINFO_EXTENSION);
+        $ext = pathinfo($this->filename, PATHINFO_EXTENSION);
         if (!empty($ext)) {
             $filename = $filename . '.' . $ext;
         }

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -17,8 +17,9 @@ interface TransformerInterface
      * @param \Psr\Http\Message\UploadedFileInterface $data the data being submitted for a save
      * @param string           $field the field for which data will be saved
      * @param array            $settings the settings for the current field
+     * @param string           $filename from the processor to use
      */
-    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings);
+    public function __construct(Table $table, EntityInterface $entity, UploadedFileInterface $data, string $field, array $settings, string $filename);
 
     /**
      * Creates a set of files from the initial data and returns them as key/value

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -113,7 +113,7 @@ class UploadBehavior extends Behavior
             $basepath = $path->basepath();
             $filename = $path->filename();
 
-            $files = $this->constructFiles($entity, $data, $field, $settings, $basepath);
+            $files = $this->constructFiles($entity, $data, $field, $settings, $basepath, $filename);
 
             $writer = $this->getWriter($entity, $data, $field, $settings);
             $success = $writer->write($files);
@@ -224,6 +224,8 @@ class UploadBehavior extends Behavior
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @param string $basepath a basepath where the files are written to
+     * @param string $filename Filename from processor to use
+     *
      * @return array key/value pairs of temp files mapping to their names
      */
     public function constructFiles(
@@ -231,19 +233,20 @@ class UploadBehavior extends Behavior
         UploadedFileInterface $data,
         string $field,
         array $settings,
-        string $basepath
+        string $basepath,
+        string $filename
     ): array {
         $basepath = substr($basepath, -1) == DS ? $basepath : $basepath . DS;
         $transformerClass = Hash::get($settings, 'transformer', DefaultTransformer::class);
         $results = [];
         if (is_subclass_of($transformerClass, TransformerInterface::class)) {
-            $transformer = new $transformerClass($this->_table, $entity, $data, $field, $settings);
+            $transformer = new $transformerClass($this->_table, $entity, $data, $field, $settings, $filename);
             $results = $transformer->transform();
             foreach ($results as $key => $value) {
                 $results[$key] = $basepath . $value;
             }
         } elseif (is_callable($transformerClass)) {
-            $results = $transformerClass($this->_table, $entity, $data, $field, $settings);
+            $results = $transformerClass($this->_table, $entity, $data, $field, $settings, $filename);
             foreach ($results as $key => $value) {
                 $results[$key] = $basepath . $value;
             }

--- a/tests/TestCase/Database/Type/FileTypeTest.php
+++ b/tests/TestCase/Database/Type/FileTypeTest.php
@@ -8,11 +8,38 @@ use Josegonzalez\Upload\Database\Type\FileType;
 
 class FileTypeTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->type = new FileType('field');
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->type);
+        parent::tearDown();
+    }
+
     public function testMarshal()
     {
-        $type = new FileType('field');
-        $this->assertEquals('expected', $type->marshal('expected'));
-        $this->assertEquals([], $type->marshal([]));
-        $this->assertEquals(['key'], $type->marshal(['key']));
+        $this->assertEquals('expected', $this->type->marshal('expected'));
+        $this->assertEquals([], $this->type->marshal([]));
+        $this->assertEquals(['key'], $this->type->marshal(['key']));
+    }
+
+    public function testToDatabase()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\DriverInterface')->getMock();
+        $this->assertEquals('expected', $this->type->toDatabase('expected', $driver));
+        $this->assertEquals([], $this->type->toDatabase([], $driver));
+        $this->assertEquals(['key'], $this->type->toDatabase(['key'], $driver));
+    }
+
+    public function testToPHP()
+    {
+        $driver = $this->getMockBuilder('Cake\Database\DriverInterface')->getMock();
+        $this->assertEquals('expected', $this->type->toPHP('expected', $driver));
+        $this->assertEquals([], $this->type->toPHP([], $driver));
+        $this->assertEquals(['key'], $this->type->toPHP(['key'], $driver));
     }
 }

--- a/tests/TestCase/File/Path/DefaultProcessorTest.php
+++ b/tests/TestCase/File/Path/DefaultProcessorTest.php
@@ -13,7 +13,7 @@ class DefaultProcessorTest extends TestCase
     {
         $entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
-        $data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK);
+        $data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename.png');
         $field = 'field';
         $settings = [];
         $processor = new DefaultProcessor($table, $entity, $data, $field, $settings);

--- a/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
+++ b/tests/TestCase/File/Path/Filename/DefaultTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Josegonzalez\Upload\Test\TestCase\File\Path\Filename;
 
 use Cake\TestSuite\TestCase;
+use Cake\Utility\Text;
 use Laminas\Diactoros\UploadedFile;
 
 class DefaultTraitTest extends TestCase
@@ -12,15 +13,20 @@ class DefaultTraitTest extends TestCase
     {
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->settings = [];
-        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename');
-        $this->assertEquals('filename', $mock->filename());
+        $mock->data = 'filename.png';
+        $this->assertEquals('filename.png', $mock->filename());
+
+        $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
+        $mock->settings = [];
+        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename.png');
+        $this->assertEquals('filename.png', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->settings = [
             'nameCallback' => 'not_callable',
         ];
-        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename');
-        $this->assertEquals('filename', $mock->filename());
+        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename.png');
+        $this->assertEquals('filename.png', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->settings = [
@@ -28,8 +34,8 @@ class DefaultTraitTest extends TestCase
                 return $data->getClientFilename();
             },
         ];
-        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename');
-        $this->assertEquals('filename', $mock->filename());
+        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename.png');
+        $this->assertEquals('filename.png', $mock->filename());
 
         $mock = $this->getMockForTrait('Josegonzalez\Upload\File\Path\Filename\DefaultTrait');
         $mock->entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
@@ -37,10 +43,13 @@ class DefaultTraitTest extends TestCase
         $mock->field = 'field';
         $mock->settings = [
             'nameCallback' => function ($table, $entity, $data, $field, $settings) {
-                return $data->getClientFilename();
+                $pathparts = pathinfo($data->getClientFilename());
+                $filename = Text::uuid() . '.' . strtolower($pathparts['extension']);
+
+                return $filename;
             },
         ];
-        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename');
-        $this->assertEquals('filename', $mock->filename());
+        $mock->data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'filename.png');
+        $this->assertEquals(40, strlen($mock->filename()));
     }
 }

--- a/tests/TestCase/File/Transformer/DefaultTransformerTest.php
+++ b/tests/TestCase/File/Transformer/DefaultTransformerTest.php
@@ -17,10 +17,10 @@ class DefaultTransformerTest extends TestCase
 
         $field = 'field';
         $settings = [];
-        $this->transformer = new DefaultTransformer($table, $entity, $this->uploadedFile, $field, $settings);
+        $this->transformer = new DefaultTransformer($table, $entity, $this->uploadedFile, $field, $settings, 'foo.txt');
     }
 
-    public function testIsProcessorInterface()
+    public function testIsTransformerInterface()
     {
         $this->assertInstanceOf('Josegonzalez\Upload\File\Transformer\TransformerInterface', $this->transformer);
     }

--- a/tests/TestCase/File/Transformer/SlugTransformerTest.php
+++ b/tests/TestCase/File/Transformer/SlugTransformerTest.php
@@ -16,7 +16,7 @@ class SlugTransformerTest extends TestCase
         $data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'foo é À.TXT');
         $field = 'field';
         $settings = [];
-        $this->transformer = new SlugTransformer($table, $entity, $data, $field, $settings);
+        $this->transformer = new SlugTransformer($table, $entity, $data, $field, $settings, 'foo é À.TXT');
     }
 
     public function testTransform()
@@ -29,7 +29,8 @@ class SlugTransformerTest extends TestCase
         $entity = $this->getMockBuilder('Cake\ORM\Entity')->getMock();
         $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
         $data = new UploadedFile(fopen('php://temp', 'wb+'), 150, UPLOAD_ERR_OK, 'foo é À');
-        $transformer = new SlugTransformer($table, $entity, $data, 'field', []);
+
+        $transformer = new SlugTransformer($table, $entity, $data, 'field', [], 'foo é À');
         $this->assertEquals(['php://temp' => 'foo-e-a'], $transformer->transform());
     }
 }

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -626,42 +626,50 @@ class UploadBehaviorTest extends TestCase
 
     public function testConstructFiles()
     {
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt');
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
+            $data,
             'field',
             [],
-            'path'
+            'path',
+            'file.txt'
         );
         $this->assertEquals(['php://temp' => 'path/file.txt'], $files);
 
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt');
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
+            $data,
             'field',
             [],
-            'some/path'
+            'some/path',
+            'file.txt'
         );
         $this->assertEquals(['php://temp' => 'some/path/file.txt'], $files);
     }
 
     public function testConstructFilesWithBasePathEndingDS()
     {
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt');
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
+            $data,
             'field',
             [],
-            'path/'
+            'path/',
+            'file.txt'
         );
         $this->assertEquals(['php://temp' => 'path/file.txt'], $files);
 
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt');
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
+            $data,
             'field',
             [],
-            'some/path/'
+            'some/path/',
+            'file.txt'
         );
         $this->assertEquals(['php://temp' => 'some/path/file.txt'], $files);
     }
@@ -671,12 +679,14 @@ class UploadBehaviorTest extends TestCase
         $callable = function () {
             return ['php://temp' => 'file.text'];
         };
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt');
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
+            $data,
             'field',
             ['transformer' => $callable],
-            'some/path'
+            'some/path',
+            'file.txt'
         );
         $this->assertEquals(['php://temp' => 'some/path/file.text'], $files);
     }
@@ -686,12 +696,14 @@ class UploadBehaviorTest extends TestCase
         $callable = function () {
             return ['php://temp' => 'file.text'];
         };
+        $data = new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK);
         $files = $this->behavior->constructFiles(
             $this->entity,
-            new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK),
+            $data,
             'field',
             ['transformer' => $callable],
-            'some/path/'
+            'some/path/',
+            ''
         );
         $this->assertEquals(['php://temp' => 'some/path/file.text'], $files);
     }
@@ -704,7 +716,8 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             ['transformer' => 'UnexpectedValueException'],
-            'path'
+            'path',
+            'file.txt'
         );
     }
 

--- a/tests/TestCase/PluginTest.php
+++ b/tests/TestCase/PluginTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Josegonzalez\Upload\Test\TestCase;
+
+use Cake\Database\TypeFactory;
+use Cake\TestSuite\TestCase;
+use Josegonzalez\Upload\Plugin;
+
+class PluginTest extends TestCase
+{
+    public function testBootstrap()
+    {
+        $mock = $this->getMockBuilder('Cake\Core\PluginApplicationInterface')->getMock();
+        $plugin = new Plugin([]);
+        $plugin->bootstrap($mock);
+        $this->assertEquals('Josegonzalez\Upload\Database\Type\FileType', TypeFactory::getMap('upload.file'));
+    }
+}


### PR DESCRIPTION
Fixes #532 
I tried to use the `ProcessorInterface` but this lead to the nameCallback being called multiple times. So the best option I could find was to pass the desired filename as a argument to the `TransformerInterface` to replicate how cakephp-upload 4.x worked.