### PR TITLE
[cake-4.x] Fixing validators to use UploadedFileInterface

### DIFF
--- a/src/Validation/Traits/ImageValidationTrait.php
+++ b/src/Validation/Traits/ImageValidationTrait.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Josegonzalez\Upload\Validation\Traits;
 
+use Psr\Http\Message\UploadedFileInterface;
+
 trait ImageValidationTrait
 {
     /**
@@ -14,11 +16,16 @@ trait ImageValidationTrait
      */
     public static function isAboveMinWidth($check, int $width): bool
     {
-        // Non-file uploads also mean the height is too big
-        if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
-            return false;
+        if ($check instanceof UploadedFileInterface) {
+            $file = $check->getStream()->getMetadata('uri');
+        } else {
+            // Non-file uploads also mean the height is too big
+            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+                return false;
+            }
+            $file = $check['tmp_name'];
         }
-        [$imgWidth] = getimagesize($check['tmp_name']);
+        [$imgWidth] = getimagesize($file);
 
         return $width > 0 && $imgWidth >= $width;
     }
@@ -32,11 +39,17 @@ trait ImageValidationTrait
      */
     public static function isBelowMaxWidth($check, int $width): bool
     {
-        // Non-file uploads also mean the height is too big
-        if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
-            return false;
+        if ($check instanceof UploadedFileInterface) {
+            $file = $check->getStream()->getMetadata('uri');
+        } else {
+            // Non-file uploads also mean the height is too big
+            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+                return false;
+            }
+
+            $file = $check['tmp_name'];
         }
-        [$imgWidth] = getimagesize($check['tmp_name']);
+        [$imgWidth] = getimagesize($file);
 
         return $width > 0 && $imgWidth <= $width;
     }
@@ -50,11 +63,16 @@ trait ImageValidationTrait
      */
     public static function isAboveMinHeight($check, int $height): bool
     {
-        // Non-file uploads also mean the height is too big
-        if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
-            return false;
+        if ($check instanceof UploadedFileInterface) {
+            $file = $check->getStream()->getMetadata('uri');
+        } else {
+            // Non-file uploads also mean the height is too big
+            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+                return false;
+            }
+            $file = $check['tmp_name'];
         }
-        [, $imgHeight] = getimagesize($check['tmp_name']);
+        [, $imgHeight] = getimagesize($file);
 
         return $height > 0 && $imgHeight >= $height;
     }
@@ -68,11 +86,16 @@ trait ImageValidationTrait
      */
     public static function isBelowMaxHeight($check, int $height): bool
     {
-        // Non-file uploads also mean the height is too big
-        if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
-            return false;
+        if ($check instanceof UploadedFileInterface) {
+            $file = $check->getStream()->getMetadata('uri');
+        } else {
+            // Non-file uploads also mean the height is too big
+            if (!isset($check['tmp_name']) || !strlen($check['tmp_name'])) {
+                return false;
+            }
+            $file = $check['tmp_name'];
         }
-        [, $imgHeight] = getimagesize($check['tmp_name']);
+        [, $imgHeight] = getimagesize($file);
 
         return $height > 0 && $imgHeight <= $height;
     }

--- a/src/Validation/Traits/UploadValidationTrait.php
+++ b/src/Validation/Traits/UploadValidationTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Josegonzalez\Upload\Validation\Traits;
 
 use Cake\Utility\Hash;
+use Psr\Http\Message\UploadedFileInterface;
 
 trait UploadValidationTrait
 {
@@ -16,6 +17,10 @@ trait UploadValidationTrait
      */
     public static function isUnderPhpSizeLimit($check): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getError() !== UPLOAD_ERR_INI_SIZE;
+        }
+
         return Hash::get($check, 'error') !== UPLOAD_ERR_INI_SIZE;
     }
 
@@ -28,6 +33,10 @@ trait UploadValidationTrait
      */
     public static function isUnderFormSizeLimit($check): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getError() !== UPLOAD_ERR_FORM_SIZE;
+        }
+
         return Hash::get($check, 'error') !== UPLOAD_ERR_FORM_SIZE;
     }
 
@@ -39,6 +48,10 @@ trait UploadValidationTrait
      */
     public static function isCompletedUpload($check): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getError() !== UPLOAD_ERR_PARTIAL;
+        }
+
         return Hash::get($check, 'error') !== UPLOAD_ERR_PARTIAL;
     }
 
@@ -50,6 +63,10 @@ trait UploadValidationTrait
      */
     public static function isFileUpload($check): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getError() !== UPLOAD_ERR_NO_FILE;
+        }
+
         return Hash::get($check, 'error') !== UPLOAD_ERR_NO_FILE;
     }
 
@@ -61,6 +78,10 @@ trait UploadValidationTrait
      */
     public static function isSuccessfulWrite($check): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getError() !== UPLOAD_ERR_CANT_WRITE;
+        }
+
         return Hash::get($check, 'error') !== UPLOAD_ERR_CANT_WRITE;
     }
 
@@ -73,6 +94,10 @@ trait UploadValidationTrait
      */
     public static function isAboveMinSize($check, $size): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getSize() >= $size;
+        }
+
         return !empty($check['size']) && $check['size'] >= $size;
     }
 
@@ -85,6 +110,10 @@ trait UploadValidationTrait
      */
     public static function isBelowMaxSize($check, $size): bool
     {
+        if ($check instanceof UploadedFileInterface) {
+            return $check->getSize() <= $size;
+        }
+
         return !empty($check['size']) && $check['size'] <= $size;
     }
 }

--- a/tests/TestCase/Validation/ImageValidationTest.php
+++ b/tests/TestCase/Validation/ImageValidationTest.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\Validation\ImageValidation;
+use Laminas\Diactoros\UploadedFile;
 use VirtualFileSystem\FileSystem as Vfs;
 
 class ImageValidationTest extends TestCase
@@ -35,6 +36,10 @@ class ImageValidationTest extends TestCase
 
     public function testIsAboveMinWidth()
     {
+        $file = new UploadedFile($this->data['tmp_name'], 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(ImageValidation::isAboveMinWidth($file, 10));
+        $this->assertFalse(ImageValidation::isAboveMinWidth($file, 30));
+
         $this->assertTrue(ImageValidation::isAboveMinWidth($this->data, 10));
         $this->assertFalse(ImageValidation::isAboveMinWidth($this->data, 30));
 
@@ -48,6 +53,10 @@ class ImageValidationTest extends TestCase
 
     public function testIsBelowMaxWidth()
     {
+        $file = new UploadedFile($this->data['tmp_name'], 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(ImageValidation::isBelowMaxWidth($file, 30));
+        $this->assertFalse(ImageValidation::isBelowMaxWidth($file, 10));
+
         $this->assertTrue(ImageValidation::isBelowMaxWidth($this->data, 30));
         $this->assertFalse(ImageValidation::isBelowMaxWidth($this->data, 10));
 
@@ -61,6 +70,10 @@ class ImageValidationTest extends TestCase
 
     public function testIsAboveMinHeight()
     {
+        $file = new UploadedFile($this->data['tmp_name'], 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(ImageValidation::isAboveMinHeight($file, 10));
+        $this->assertFalse(ImageValidation::isAboveMinHeight($file, 30));
+
         $this->assertTrue(ImageValidation::isAboveMinHeight($this->data, 10));
         $this->assertFalse(ImageValidation::isAboveMinHeight($this->data, 30));
 
@@ -74,6 +87,10 @@ class ImageValidationTest extends TestCase
 
     public function testIsBelowMaxHeight()
     {
+        $file = new UploadedFile($this->data['tmp_name'], 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(ImageValidation::isBelowMaxHeight($file, 30));
+        $this->assertFalse(ImageValidation::isBelowMaxHeight($file, 10));
+
         $this->assertTrue(ImageValidation::isBelowMaxHeight($this->data, 30));
         $this->assertFalse(ImageValidation::isBelowMaxHeight($this->data, 10));
 

--- a/tests/TestCase/Validation/UploadValidationTest.php
+++ b/tests/TestCase/Validation/UploadValidationTest.php
@@ -5,6 +5,7 @@ namespace Josegonzalez\Upload\Test\TestCase\Validation;
 
 use Cake\TestSuite\TestCase;
 use Josegonzalez\Upload\Validation\UploadValidation;
+use Laminas\Diactoros\UploadedFile;
 
 class UploadValidationTest extends TestCase
 {
@@ -25,30 +26,60 @@ class UploadValidationTest extends TestCase
     {
         $this->assertTrue(UploadValidation::isUnderPhpSizeLimit($this->data + ['error' => UPLOAD_ERR_OK]));
         $this->assertFalse(UploadValidation::isUnderPhpSizeLimit($this->data + ['error' => UPLOAD_ERR_INI_SIZE]));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isUnderPhpSizeLimit($file));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_INI_SIZE, 'sample.txt', 'text/plain');
+        $this->assertFalse(UploadValidation::isUnderPhpSizeLimit($file));
     }
 
     public function testIsUnderFormSizeLimit()
     {
         $this->assertTrue(UploadValidation::isUnderFormSizeLimit($this->data + ['error' => UPLOAD_ERR_OK]));
         $this->assertFalse(UploadValidation::isUnderFormSizeLimit($this->data + ['error' => UPLOAD_ERR_FORM_SIZE]));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isUnderFormSizeLimit($file));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_FORM_SIZE, 'sample.txt', 'text/plain');
+        $this->assertFalse(UploadValidation::isUnderFormSizeLimit($file));
     }
 
     public function testIsCompletedUpload()
     {
         $this->assertTrue(UploadValidation::isCompletedUpload($this->data + ['error' => UPLOAD_ERR_OK]));
         $this->assertFalse(UploadValidation::isCompletedUpload($this->data + ['error' => UPLOAD_ERR_PARTIAL]));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isCompletedUpload($file));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_PARTIAL, 'sample.txt', 'text/plain');
+        $this->assertFalse(UploadValidation::isCompletedUpload($file));
     }
 
     public function testIsFileUpload()
     {
         $this->assertTrue(UploadValidation::isFileUpload($this->data + ['error' => UPLOAD_ERR_OK]));
         $this->assertFalse(UploadValidation::isFileUpload($this->data + ['error' => UPLOAD_ERR_NO_FILE]));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isFileUpload($file));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_NO_FILE, 'sample.txt', 'text/plain');
+        $this->assertFalse(UploadValidation::isFileUpload($file));
     }
 
     public function testIsSuccessfulWrite()
     {
         $this->assertTrue(UploadValidation::isSuccessfulWrite($this->data + ['error' => UPLOAD_ERR_OK]));
         $this->assertFalse(UploadValidation::isSuccessfulWrite($this->data + ['error' => UPLOAD_ERR_CANT_WRITE]));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isSuccessfulWrite($file));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_CANT_WRITE, 'sample.txt', 'text/plain');
+        $this->assertFalse(UploadValidation::isSuccessfulWrite($file));
     }
 
     public function testIsAboveMinSize()
@@ -62,6 +93,10 @@ class UploadValidationTest extends TestCase
 
         unset($this->data['size']);
         $this->assertFalse(UploadValidation::isAboveMinSize($this->data, 200));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isAboveMinSize($file, 200));
+        $this->assertFalse(UploadValidation::isAboveMinSize($file, 250));
     }
 
     public function testIsBelowMaxSize()
@@ -75,5 +110,9 @@ class UploadValidationTest extends TestCase
 
         unset($this->data['size']);
         $this->assertFalse(UploadValidation::isBelowMaxSize($this->data, 200));
+
+        $file = new UploadedFile(fopen('php://temp', 'rw+'), 200, UPLOAD_ERR_OK, 'sample.txt', 'text/plain');
+        $this->assertTrue(UploadValidation::isBelowMaxSize($file, 200));
+        $this->assertFalse(UploadValidation::isBelowMaxSize($file, 150));
     }
 }


### PR DESCRIPTION
In CakePHP 4.x the file is now wrapped in an `UploadedFileInterface` when doing validation checks they currently fail due to array access on an object. This PR corrects it to use the UploadedFileInterface and fall back to the array style.