### PR TITLE
Fixing case when an invokeable object is used as a callback

### DIFF
--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -17,6 +17,10 @@ trait DefaultTrait
     public function filename(): string
     {
         $processor = Hash::get($this->settings, 'nameCallback', null);
+        if (is_object($processor) && method_exists($processor, '__invoke')) {
+            return $processor($this->table, $this->entity, $this->data, $this->field, $this->settings);
+        }
+
         if (is_callable($processor)) {
             $numberOfParameters = (new \ReflectionFunction($processor))->getNumberOfParameters();
             if ($numberOfParameters == 2) {


### PR DESCRIPTION
Obviously nobody else had yet the desire to move the sometimes pretty long callbacks into proper objects. Well, we did and figured out the plugin doesn't like it. 😃 This fixes the problem.