### PR TITLE
Update examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -213,7 +213,7 @@ This example uses the Imagine library. It can be installed through composer:
                         'type' => 'photo_type',
                     ],
                     'nameCallback' => function ($table, $entity, $data, $field, $settings) {
-                        return strtolower($data['name']);
+                        return strtolower($data->getClientFilename());
                     },
                     'transformer' => function ($table, $entity, $data, $field, $settings, $filename) {
                         $extension = pathinfo($filename, PATHINFO_EXTENSION);


### PR DESCRIPTION
using 
return strtolower($data['name']);
gives: 
Cannot use object of type Laminas\Diactoros\UploadedFile as array