### PR TITLE
Fix beforeMarshall if file uploads are array

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -74,7 +74,10 @@ class UploadBehavior extends Behavior
             if (!$validator->isEmptyAllowed($field, false)) {
                 continue;
             }
-            if (!empty($dataArray[$field]) && $dataArray[$field]->getError() !== UPLOAD_ERR_NO_FILE) {
+            if (
+                !empty($dataArray[$field]) &&
+                ($dataArray[$field] instanceof UploadedFileInterface ? $dataArray[$field]->getError() : $dataArray[$field]['error']) !== UPLOAD_ERR_NO_FILE
+            ) {
                 continue;
             }
             if (isset($data[$field])) {

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -76,7 +76,10 @@ class UploadBehavior extends Behavior
             }
             if (
                 !empty($dataArray[$field]) &&
-                ($dataArray[$field] instanceof UploadedFileInterface ? $dataArray[$field]->getError() : $dataArray[$field]['error']) !== UPLOAD_ERR_NO_FILE
+                ($dataArray[$field] instanceof UploadedFileInterface
+                    ? $dataArray[$field]->getError()
+                    : $dataArray[$field]['error']
+                ) !== UPLOAD_ERR_NO_FILE
             ) {
                 continue;
             }

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -803,11 +803,11 @@ class UploadBehaviorTest extends TestCase
     {
         return array_map(
             fn(UploadedFileInterface $file) => [
-                "tmp_name" => "",
-                "error" => $file->getError(),
-                "name" => $file->getClientFilename(),
-                "type" => $file->getClientMediaType(),
-                "size" => $file->getSize()
+                'tmp_name' => '',
+                'error' => $file->getError(),
+                'name' => $file->getClientFilename(),
+                'type' => $file->getClientMediaType(),
+                'size' => $file->getSize(),
             ],
             $data
         );

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -11,6 +11,7 @@ use Josegonzalez\Upload\File\Transformer\SlugTransformer;
 use Josegonzalez\Upload\Model\Behavior\UploadBehavior;
 use Josegonzalez\Upload\Test\Stub\ChildBehavior;
 use Laminas\Diactoros\UploadedFile;
+use Psr\Http\Message\UploadedFileInterface;
 use ReflectionClass;
 
 class UploadBehaviorTest extends TestCase
@@ -256,6 +257,40 @@ class UploadBehaviorTest extends TestCase
         $data = new ArrayObject($this->dataError);
         $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
         $this->assertEquals(new ArrayObject($this->dataError), $data);
+    }
+
+    public function testBeforeMarshalDataAsArray()
+    {
+        $validator = $this->getMockBuilder('Cake\Validation\Validator')->getMock();
+        $validator->expects($this->atLeastOnce())
+                  ->method('isEmptyAllowed')
+                  ->will($this->returnValue(true));
+
+        $table = $this->getMockBuilder('Cake\ORM\Table')->getMock();
+        $table->expects($this->atLeastOnce())
+                    ->method('getValidator')
+                    ->will($this->returnValue($validator));
+
+        $methods = array_diff($this->behaviorMethods, ['beforeMarshal']);
+        $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
+            ->onlyMethods($methods)
+            ->setConstructorArgs([$table, $this->settings])
+            ->getMock();
+        $behavior->expects($this->any())
+                 ->method('getConfig')
+                 ->will($this->returnValue($this->settings));
+
+        $data = new ArrayObject(
+            $this->transformUploadedFilesToArray($this->dataOk)
+        );
+        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
+        $this->assertEquals(new ArrayObject($this->transformUploadedFilesToArray($this->dataOk)), $data);
+
+        $data = new ArrayObject(
+            $this->transformUploadedFilesToArray($this->dataError)
+        );
+        $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
+        $this->assertEquals(new ArrayObject([]), $data);
     }
 
     public function testBeforeSaveNoUpload()
@@ -762,5 +797,19 @@ class UploadBehaviorTest extends TestCase
         ];
 
         $this->assertEquals($expected, $behavior->constructedFiles);
+    }
+
+    private function transformUploadedFilesToArray(array $data): array
+    {
+        return array_map(
+            fn(UploadedFileInterface $file) => [
+                "tmp_name" => "",
+                "error" => $file->getError(),
+                "name" => $file->getClientFilename(),
+                "type" => $file->getClientMediaType(),
+                "size" => $file->getSize()
+            ],
+            $data
+        );
     }
 }


### PR DESCRIPTION
Fix error "Call to a member function getError() on array" when uploaded file is an array.