### PR TITLE
8.x - Fix `afterDelete` expecting an `UploadedFileInterface` object.

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -176,10 +176,7 @@ class UploadBehavior extends Behavior
             if ($callback && is_callable($callback)) {
                 $files = $callback($path, $entity, $field, $settings);
             } else {
-                /** @var \Psr\Http\Message\UploadedFileInterface $uploaded */
-                $uploaded = $entity->get($field);
-
-                $files = [$path . $uploaded->getClientFilename()];
+                $files = [$path . $entity->get($field)];
             }
 
             $writer = $this->getWriter($entity, null, $field, $settings);


### PR DESCRIPTION
Reverts some of #593. The entity read from the DB will not hold uploaded file instances.

ps. I don't have time for it right now, but seeing how this slipped in, the tests are IMHO in dire need of de-mocking. There's so much mocking going on that could possibly hide all sorts of problems, it's wild.

Previously there was for example `$this->entity->field` being set and passed to expectations, but it was always `null`, because it's all mocked, still the tests passed because there were no type hints on the arguments where the value would flow through.