### PR TITLE
Changing default directory_visibility

### DIFF
--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -145,6 +145,7 @@ class DefaultWriter implements WriterInterface
         if ($adapter instanceof FilesystemAdapter) {
             return new Filesystem($adapter, Hash::get($settings, 'filesystem.options', [
                 'visibility' => Visibility::PUBLIC,
+                'directory_visibility' => Visibility::PUBLIC,
             ]));
         }
 


### PR DESCRIPTION
In an environment where we have a web server running with the `nobody` user and PHP running in its own user, it is not possible by default for http server to directly access files in folders created by this plugin. I believe that if the file has public visibility by default, it makes sense to me that the folder should also be.