### PR TITLE
Allowing no file in the PathProcessor

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
 			identifier: missingType.generics
 
 		-
-			message: "#^Parameter \\#1 \\$field of method Cake\\\\Datasource\\\\EntityInterface\\:\\:get\\(\\) expects string, array\\<int, string\\>\\|string given\\.$#"
+			message: '#^Parameter \#1 \$field of method Cake\\Datasource\\EntityInterface\:\:get\(\) expects string, array\<string\>\|string given\.$#'
 			count: 1
 			path: src/File/Path/DefaultProcessor.php
 

--- a/src/File/Path/Basepath/DefaultTrait.php
+++ b/src/File/Path/Basepath/DefaultTrait.php
@@ -53,17 +53,17 @@ trait DefaultTrait
                 if ($value === null) {
                     throw new LogicException(sprintf(
                         'Field value for substitution is missing: %s',
-                        $field
+                        $field,
                     ));
                 } elseif (!is_scalar($value)) {
                     throw new LogicException(sprintf(
                         'Field value for substitution must be a integer, float, string or boolean: %s',
-                        $field
+                        $field,
                     ));
                 } elseif (strlen((string)$value) < 1) {
                     throw new LogicException(sprintf(
                         'Field value for substitution must be non-zero in length: %s',
-                        $field
+                        $field,
                     ));
                 }
 
@@ -74,7 +74,7 @@ trait DefaultTrait
         return str_replace(
             array_keys($replacements),
             array_values($replacements),
-            $path
+            $path,
         );
     }
 }

--- a/src/File/Path/DefaultProcessor.php
+++ b/src/File/Path/DefaultProcessor.php
@@ -63,7 +63,7 @@ class DefaultProcessor implements ProcessorInterface
         EntityInterface $entity,
         UploadedFileInterface|string $data,
         string $field,
-        array $settings
+        array $settings,
     ) {
         $this->table = $table;
         $this->entity = $entity;

--- a/src/File/Path/Filename/DefaultTrait.php
+++ b/src/File/Path/Filename/DefaultTrait.php
@@ -23,7 +23,7 @@ trait DefaultTrait
                 $this->entity,
                 $this->data,
                 $this->field,
-                $this->settings
+                $this->settings,
             );
         }
 

--- a/src/File/Path/ProcessorInterface.php
+++ b/src/File/Path/ProcessorInterface.php
@@ -23,7 +23,7 @@ interface ProcessorInterface
         EntityInterface $entity,
         string|UploadedFileInterface $data,
         string $field,
-        array $settings
+        array $settings,
     );
 
     /**

--- a/src/File/Transformer/DefaultTransformer.php
+++ b/src/File/Transformer/DefaultTransformer.php
@@ -23,7 +23,7 @@ class DefaultTransformer implements TransformerInterface
         protected EntityInterface $entity,
         protected UploadedFileInterface $data,
         protected string $field,
-        protected array $settings
+        protected array $settings,
     ) {
     }
 

--- a/src/File/Transformer/TransformerInterface.php
+++ b/src/File/Transformer/TransformerInterface.php
@@ -23,7 +23,7 @@ interface TransformerInterface
         EntityInterface $entity,
         UploadedFileInterface $data,
         string $field,
-        array $settings
+        array $settings,
     );
 
     /**

--- a/src/File/Writer/DefaultWriter.php
+++ b/src/File/Writer/DefaultWriter.php
@@ -31,7 +31,7 @@ class DefaultWriter implements WriterInterface
         protected EntityInterface $entity,
         protected ?UploadedFileInterface $data,
         protected string $field,
-        protected array $settings
+        protected array $settings,
     ) {
     }
 

--- a/src/File/Writer/WriterInterface.php
+++ b/src/File/Writer/WriterInterface.php
@@ -23,7 +23,7 @@ interface WriterInterface
         EntityInterface $entity,
         ?UploadedFileInterface $data,
         string $field,
-        array $settings
+        array $settings,
     );
 
     /**

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -206,7 +206,7 @@ class UploadBehavior extends Behavior
         EntityInterface $entity,
         string|UploadedFileInterface|null $data,
         string $field,
-        array $settings
+        array $settings,
     ): ProcessorInterface {
         /** @var class-string<\Josegonzalez\Upload\File\Path\ProcessorInterface> $processorClass */
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -197,19 +197,23 @@ class UploadBehavior extends Behavior
      * for a given file upload
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity
-     * @param \Psr\Http\Message\UploadedFileInterface|string $data the data being submitted for a save or the filename
+     * @param \Psr\Http\Message\UploadedFileInterface|string|null $data the data being submitted for a save or the filename
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Path\ProcessorInterface
      */
     public function getPathProcessor(
         EntityInterface $entity,
-        string|UploadedFileInterface $data,
+        string|UploadedFileInterface|null $data,
         string $field,
         array $settings
     ): ProcessorInterface {
         /** @var class-string<\Josegonzalez\Upload\File\Path\ProcessorInterface> $processorClass */
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
+
+        if ($data === null) {
+            $data = "";
+        }
 
         return new $processorClass($this->_table, $entity, $data, $field, $settings);
     }

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -206,7 +206,7 @@ class UploadBehavior extends Behavior
         EntityInterface $entity,
         string|UploadedFileInterface $data,
         string $field,
-        array $settings
+        array $settings,
     ): ProcessorInterface {
         /** @var class-string<\Josegonzalez\Upload\File\Path\ProcessorInterface> $processorClass */
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
@@ -227,7 +227,7 @@ class UploadBehavior extends Behavior
         EntityInterface $entity,
         ?UploadedFileInterface $data,
         string $field,
-        array $settings
+        array $settings,
     ): WriterInterface {
         /** @var class-string<\Josegonzalez\Upload\File\Writer\WriterInterface> $writerClass */
         $writerClass = Hash::get($settings, 'writer', DefaultWriter::class);
@@ -262,7 +262,7 @@ class UploadBehavior extends Behavior
         UploadedFileInterface $data,
         string $field,
         array $settings,
-        array $pathinfo
+        array $pathinfo,
     ): array {
         $basepath = $pathinfo['basepath'];
         $filename = $pathinfo['filename'];
@@ -284,7 +284,7 @@ class UploadBehavior extends Behavior
         } else {
             throw new UnexpectedValueException(sprintf(
                 "'transformer' not set to instance of TransformerInterface: %s",
-                $transformerClass
+                $transformerClass,
             ));
         }
 

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -197,23 +197,19 @@ class UploadBehavior extends Behavior
      * for a given file upload
      *
      * @param \Cake\Datasource\EntityInterface $entity an entity
-     * @param \Psr\Http\Message\UploadedFileInterface|string|null $data the data being submitted for a save or the filename
+     * @param \Psr\Http\Message\UploadedFileInterface|string $data the data being submitted for a save or the filename
      * @param string $field the field for which data will be saved
      * @param array $settings the settings for the current field
      * @return \Josegonzalez\Upload\File\Path\ProcessorInterface
      */
     public function getPathProcessor(
         EntityInterface $entity,
-        string|UploadedFileInterface|null $data,
+        string|UploadedFileInterface $data,
         string $field,
-        array $settings,
+        array $settings
     ): ProcessorInterface {
         /** @var class-string<\Josegonzalez\Upload\File\Path\ProcessorInterface> $processorClass */
         $processorClass = Hash::get($settings, 'pathProcessor', DefaultProcessor::class);
-
-        if ($data === null) {
-            $data = "";
-        }
 
         return new $processorClass($this->_table, $entity, $data, $field, $settings);
     }

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -163,7 +163,11 @@ class UploadBehavior extends Behavior
         $result = true;
 
         foreach ($this->getConfig(null, []) as $field => $settings) {
-            if (in_array($field, $this->protectedFieldNames) || Hash::get($settings, 'keepFilesOnDelete', true) || $entity->get($field) === null) {
+            if (
+                in_array($field, $this->protectedFieldNames)
+                || Hash::get($settings, 'keepFilesOnDelete', true)
+                || $entity->get((string)$field) === null
+            ) {
                 continue;
             }
 

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -113,14 +113,14 @@ class UploadBehavior extends Behavior
                 continue;
             }
 
-            $data = $entity->get((string)$field);
+            $data = $entity->get($field);
             if (!$data instanceof UploadedFileInterface) {
                 continue;
             }
 
-            if ($entity->get((string)$field)->getError() !== UPLOAD_ERR_OK) {
+            if ($entity->get($field)->getError() !== UPLOAD_ERR_OK) {
                 if (Hash::get($settings, 'restoreValueOnFailure', true)) {
-                    $entity->set($field, $entity->getOriginal((string)$field));
+                    $entity->set($field, $entity->getOriginal($field));
                     $entity->setDirty($field, false);
                 }
                 continue;
@@ -166,7 +166,7 @@ class UploadBehavior extends Behavior
             if (
                 in_array($field, $this->protectedFieldNames)
                 || Hash::get($settings, 'keepFilesOnDelete', true)
-                || $entity->get((string)$field) === null
+                || $entity->get($field) === null
             ) {
                 continue;
             }
@@ -175,14 +175,14 @@ class UploadBehavior extends Behavior
             if ($entity->has($dirField)) {
                 $path = $entity->get($dirField);
             } else {
-                $path = $this->getPathProcessor($entity, $entity->get((string)$field), $field, $settings)->basepath();
+                $path = $this->getPathProcessor($entity, $entity->get($field), $field, $settings)->basepath();
             }
 
             $callback = Hash::get($settings, 'deleteCallback');
             if ($callback && is_callable($callback)) {
                 $files = $callback($path, $entity, $field, $settings);
             } else {
-                $files = [$path . $entity->get((string)$field)];
+                $files = [$path . $entity->get($field)];
             }
 
             $writer = $this->getWriter($entity, null, $field, $settings);

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -113,14 +113,14 @@ class UploadBehavior extends Behavior
                 continue;
             }
 
-            $data = $entity->get($field);
+            $data = $entity->get((string)$field);
             if (!$data instanceof UploadedFileInterface) {
                 continue;
             }
 
-            if ($entity->get($field)->getError() !== UPLOAD_ERR_OK) {
+            if ($entity->get((string)$field)->getError() !== UPLOAD_ERR_OK) {
                 if (Hash::get($settings, 'restoreValueOnFailure', true)) {
-                    $entity->set($field, $entity->getOriginal($field));
+                    $entity->set($field, $entity->getOriginal((string)$field));
                     $entity->setDirty($field, false);
                 }
                 continue;
@@ -175,14 +175,14 @@ class UploadBehavior extends Behavior
             if ($entity->has($dirField)) {
                 $path = $entity->get($dirField);
             } else {
-                $path = $this->getPathProcessor($entity, $entity->get($field), $field, $settings)->basepath();
+                $path = $this->getPathProcessor($entity, $entity->get((string)$field), $field, $settings)->basepath();
             }
 
             $callback = Hash::get($settings, 'deleteCallback');
             if ($callback && is_callable($callback)) {
                 $files = $callback($path, $entity, $field, $settings);
             } else {
-                $files = [$path . $entity->get($field)];
+                $files = [$path . $entity->get((string)$field)];
             }
 
             $writer = $this->getWriter($entity, null, $field, $settings);

--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -163,7 +163,7 @@ class UploadBehavior extends Behavior
         $result = true;
 
         foreach ($this->getConfig(null, []) as $field => $settings) {
-            if (in_array($field, $this->protectedFieldNames) || Hash::get($settings, 'keepFilesOnDelete', true)) {
+            if (in_array($field, $this->protectedFieldNames) || Hash::get($settings, 'keepFilesOnDelete', true) || $entity->get($field) === null) {
                 continue;
             }
 

--- a/tests/Stub/ChildBehavior.php
+++ b/tests/Stub/ChildBehavior.php
@@ -16,7 +16,7 @@ class ChildBehavior extends UploadBehavior
         UploadedFileInterface $data,
         string $field,
         array $settings,
-        array $pathinfo
+        array $pathinfo,
     ): array {
         $files = parent::constructFiles($entity, $data, $field, $settings, $pathinfo);
         $this->constructedFiles = $files;

--- a/tests/TestCase/File/Transformer/DefaultTransformerTest.php
+++ b/tests/TestCase/File/Transformer/DefaultTransformerTest.php
@@ -29,7 +29,7 @@ class DefaultTransformerTest extends TestCase
     {
         $this->assertEquals(
             [$this->uploadedFile->getStream()->getMetadata('uri') => 'foo.txt'],
-            $this->transformer->transform('foo.txt')
+            $this->transformer->transform('foo.txt'),
         );
     }
 }

--- a/tests/TestCase/File/Writer/DefaultWriterTest.php
+++ b/tests/TestCase/File/Writer/DefaultWriterTest.php
@@ -40,7 +40,7 @@ class DefaultWriterTest extends TestCase
             $this->entity,
             $this->data,
             $this->field,
-            $this->settings
+            $this->settings,
         );
 
         $this->vfs = Vfs::setup('tmp');

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -284,13 +284,13 @@ class UploadBehaviorTest extends TestCase
                  ->will($this->returnValue($this->settings));
 
         $data = new ArrayObject(
-            $this->transformUploadedFilesToArray($this->dataOk)
+            $this->transformUploadedFilesToArray($this->dataOk),
         );
         $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
         $this->assertEquals(new ArrayObject($this->transformUploadedFilesToArray($this->dataOk)), $data);
 
         $data = new ArrayObject(
-            $this->transformUploadedFilesToArray($this->dataError)
+            $this->transformUploadedFilesToArray($this->dataError),
         );
         $behavior->beforeMarshal(new Event('fake.event'), $data, new ArrayObject());
         $this->assertEquals(new ArrayObject([]), $data);
@@ -720,7 +720,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             [],
-            ['basepath' => 'path', 'filename' => 'file.txt']
+            ['basepath' => 'path', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'path/file.txt'], $files);
 
@@ -729,7 +729,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             [],
-            ['basepath' => 'some/path', 'filename' => 'file.txt']
+            ['basepath' => 'some/path', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'some/path/file.txt'], $files);
     }
@@ -741,7 +741,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             [],
-            ['basepath' => 'path/', 'filename' => 'file.txt']
+            ['basepath' => 'path/', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'path/file.txt'], $files);
 
@@ -750,7 +750,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             [],
-            ['basepath' => 'some/path/', 'filename' => 'file.txt']
+            ['basepath' => 'some/path/', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'some/path/file.txt'], $files);
     }
@@ -765,7 +765,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             ['transformer' => $callable],
-            ['basepath' => 'some/path', 'filename' => 'file.txt']
+            ['basepath' => 'some/path', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'some/path/file.text'], $files);
     }
@@ -780,7 +780,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK),
             'field',
             ['transformer' => $callable],
-            ['basepath' => 'some/path', 'filename' => 'file.txt']
+            ['basepath' => 'some/path', 'filename' => 'file.txt'],
         );
         $this->assertEquals(['php://temp' => 'some/path/file.text'], $files);
     }
@@ -793,7 +793,7 @@ class UploadBehaviorTest extends TestCase
             new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'),
             'field',
             ['transformer' => 'UnexpectedValueException'],
-            ['basepath' => 'path', 'filename' => 'file.txt']
+            ['basepath' => 'path', 'filename' => 'file.txt'],
         );
     }
 
@@ -841,7 +841,7 @@ class UploadBehaviorTest extends TestCase
                     'size' => $file->getSize(),
                 ];
             },
-            $data
+            $data,
         );
     }
 }

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -30,7 +30,7 @@ class UploadBehaviorTest extends TestCase
                 1,
                 UPLOAD_ERR_OK,
                 'derp',
-                'text/plain'
+                'text/plain',
             ),
         ];
 
@@ -45,7 +45,7 @@ class UploadBehaviorTest extends TestCase
                 fopen('php://temp', 'wb+'),
                 0,
                 UPLOAD_ERR_NO_FILE,
-                'derp'
+                'derp',
             ),
         ];
         $this->configError = [

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -687,49 +687,6 @@ class UploadBehaviorTest extends TestCase
         $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
     }
 
-    public function testAfterDeleteWithNoFile()
-    {
-        $dir = '/some/path/';
-
-        $methods = array_diff($this->behaviorMethods, ['afterDelete', 'config', 'setConfig', 'getConfig']);
-        $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
-            ->onlyMethods($methods)
-            ->setConstructorArgs([$this->table, $this->settings])
-            ->getMock();
-        $behavior->setConfig($this->configOk);
-
-        $this->entity->expects($this->once())
-            ->method('has')
-            ->with('dir')
-            ->will($this->returnValue(false));
-
-        $this->entity->expects($this->exactly(2))
-            ->method('get')
-            ->with('field')
-            ->will($this->returnValue(null));
-
-        $behavior->expects($this->once())
-            ->method('getPathProcessor')
-            ->with($this->entity, null, 'field', $this->configOk['field'])
-            ->willReturn($this->processor);
-
-        $this->processor->expects($this->once())
-            ->method('basepath')
-            ->willReturn($dir);
-
-        $behavior->expects($this->once())
-            ->method('getWriter')
-            ->with($this->entity, null, 'field', $this->configOk['field'])
-            ->willReturn($this->writer);
-
-        $this->writer->expects($this->once())
-            ->method('delete')
-            ->with([$dir])
-            ->willReturn([false]);
-
-        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject());
-    }
-
     public function testGetWriter()
     {
         $processor = $this->behavior->getWriter($this->entity, new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK, 'file.txt'), 'field', []);
@@ -823,6 +780,12 @@ class UploadBehaviorTest extends TestCase
     public function testGetPathProcessor()
     {
         $processor = $this->behavior->getPathProcessor($this->entity, new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK), 'field', []);
+        $this->assertInstanceOf('Josegonzalez\Upload\File\Path\ProcessorInterface', $processor);
+    }
+
+    public function testGetPathProcessorWithNoFile()
+    {
+        $processor = $this->behavior->getPathProcessor($this->entity, null, 'field', []);
         $this->assertInstanceOf('Josegonzalez\Upload\File\Path\ProcessorInterface', $processor);
     }
 

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -524,7 +524,7 @@ class UploadBehaviorTest extends TestCase
             ->with('dir')
             ->will($this->returnValue(false));
 
-        $this->entity->expects($this->exactly(2))
+        $this->entity->expects($this->exactly(3))
             ->method('get')
             ->with('field')
             ->will($this->returnValue($field));
@@ -601,7 +601,7 @@ class UploadBehaviorTest extends TestCase
         $this->configOk['field']['deleteCallback'] = null;
 
         $behavior->setConfig($this->configOk);
-        $this->entity->expects($this->exactly(2))
+        $this->entity->expects($this->exactly(3))
             ->method('get')
             ->with('field')
             ->will($this->returnValue($field));
@@ -642,7 +642,7 @@ class UploadBehaviorTest extends TestCase
         };
 
         $behavior->setConfig($this->configOk);
-        $this->entity->expects($this->exactly(4))
+        $this->entity->expects($this->exactly(5))
             ->method('get')
             ->with('field')
             ->will($this->returnValue($field));
@@ -685,6 +685,26 @@ class UploadBehaviorTest extends TestCase
             ->will($this->returnValue([true]));
 
         $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+    }
+
+    public function testAfterDeleteWithNullableFileField()
+    {
+        $methods = array_diff($this->behaviorMethods, ['afterDelete', 'config', 'setConfig', 'getConfig']);
+        $behavior = $this->getMockBuilder('Josegonzalez\Upload\Model\Behavior\UploadBehavior')
+            ->onlyMethods($methods)
+            ->setConstructorArgs([$this->table, $this->settings])
+            ->getMock();
+        $behavior->setConfig($this->configOk);
+
+        $this->entity->expects($this->once())
+            ->method('get')
+            ->with('field')
+            ->will($this->returnValue(null));
+
+        $behavior->expects($this->never())
+            ->method('getPathProcessor');
+
+        $behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject());
     }
 
     public function testGetWriter()
@@ -780,12 +800,6 @@ class UploadBehaviorTest extends TestCase
     public function testGetPathProcessor()
     {
         $processor = $this->behavior->getPathProcessor($this->entity, new UploadedFile(fopen('php://temp', 'rw+'), 1, UPLOAD_ERR_OK), 'field', []);
-        $this->assertInstanceOf('Josegonzalez\Upload\File\Path\ProcessorInterface', $processor);
-    }
-
-    public function testGetPathProcessorWithNoFile()
-    {
-        $processor = $this->behavior->getPathProcessor($this->entity, null, 'field', []);
         $this->assertInstanceOf('Josegonzalez\Upload\File\Path\ProcessorInterface', $processor);
     }
 


### PR DESCRIPTION
In cases where the database record has the file field set to null, deleting the record will result in a type error in the $data field, as null is not an acceptable value at that moment.