### PR TITLE
AfterDelete result set to event

### DIFF
--- a/src/Model/Behavior/UploadBehavior.php
+++ b/src/Model/Behavior/UploadBehavior.php
@@ -156,9 +156,9 @@ class UploadBehavior extends Behavior
      * @param \Cake\Event\EventInterface $event The afterDelete event that was fired
      * @param \Cake\Datasource\EntityInterface $entity The entity that was deleted
      * @param \ArrayObject $options the options passed to the delete method
-     * @return bool
+     * @return void
      */
-    public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): bool
+    public function afterDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void
     {
         $result = true;
 
@@ -193,7 +193,7 @@ class UploadBehavior extends Behavior
             }
         }
 
-        return $result;
+        $event->setResult($result);
     }
 
     /**

--- a/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/UploadBehaviorTest.php
@@ -460,8 +460,9 @@ class UploadBehaviorTest extends TestCase
         $this->writer->expects($this->any())
                      ->method('delete')
                      ->will($this->returnValue([true]));
-
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $event = new Event('fake.event');
+        $behavior->afterDelete($event, $this->entity, new ArrayObject());
+        $this->assertTrue($event->getResult());
     }
 
     public function testAfterDeleteFail()
@@ -485,7 +486,9 @@ class UploadBehaviorTest extends TestCase
         $this->writer->expects($this->any())
                      ->method('delete')
                      ->will($this->returnValue([false]));
-        $this->assertFalse($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $event = new Event('fake.event');
+        $behavior->afterDelete($event, $this->entity, new ArrayObject());
+        $this->assertFalse($event->getResult());
     }
 
     public function testAfterDeleteSkip()
@@ -504,7 +507,9 @@ class UploadBehaviorTest extends TestCase
             ->method('delete')
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $event = new Event('fake.event');
+        $behavior->afterDelete($event, $this->entity, new ArrayObject());
+        $this->assertTrue($event->getResult());
     }
 
     public function testAfterDeleteUsesPathProcessorToDetectPathToTheFile()
@@ -585,7 +590,9 @@ class UploadBehaviorTest extends TestCase
             ->with([$dir . $field])
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $event = new Event('fake.event');
+        $behavior->afterDelete($event, $this->entity, new ArrayObject());
+        $this->assertTrue($event->getResult());
     }
 
     public function testAfterDeleteNoDeleteCallback()
@@ -684,7 +691,9 @@ class UploadBehaviorTest extends TestCase
             ->method('delete')
             ->will($this->returnValue([true]));
 
-        $this->assertTrue($behavior->afterDelete(new Event('fake.event'), $this->entity, new ArrayObject()));
+        $event = new Event('fake.event');
+        $behavior->afterDelete($event, $this->entity, new ArrayObject());
+        $this->assertTrue($event->getResult());
     }
 
     public function testAfterDeleteWithNullableFileField()


### PR DESCRIPTION
Should fix the deprecation issue introduced by cakephp v5.2